### PR TITLE
Add typed Row.get with context receivers and ergonomic registerRowMapper

### DIFF
--- a/build-logic/src/main/kotlin/mikrom/conventions/lang/kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/mikrom/conventions/lang/kotlin-jvm.gradle.kts
@@ -11,6 +11,10 @@ plugins {
    id("org.jlleitschuh.gradle.ktlint")
 }
 
+ktlint {
+   version.set("1.8.0")
+}
+
 val mikromSettings = extensions.getByType<MikromBuildLogicSettings>()
 
 extensions.configure<KotlinJvmExtension> {
@@ -23,7 +27,7 @@ extensions.configure<KotlinJvmExtension> {
    compilerOptions {
       optIn.add("kotlin.RequiresOptIn")
       optIn.add("io.github.kantis.mikrom.MikromInternal")
-      freeCompilerArgs.add("-Xcontext-receivers")
+      freeCompilerArgs.add("-Xcontext-parameters")
    }
 
    sourceSets.configureEach {

--- a/build-logic/src/main/kotlin/mikrom/conventions/lang/kotlin-multiplatform-base.gradle.kts
+++ b/build-logic/src/main/kotlin/mikrom/conventions/lang/kotlin-multiplatform-base.gradle.kts
@@ -12,6 +12,10 @@ plugins {
    id("org.jlleitschuh.gradle.ktlint")
 }
 
+ktlint {
+   version.set("1.8.0")
+}
+
 // Base configuration for all Kotlin/Multiplatform conventions.
 // This plugin does not enable any Kotlin target. To enable a target in a subproject, prefer
 // applying specific Kotlin target convention plugins.
@@ -32,7 +36,7 @@ kotlin {
    }
 
    compilerOptions {
-      freeCompilerArgs.add("-Xcontext-receivers")
+      freeCompilerArgs.add("-Xcontext-parameters")
    }
 
    // configure all Kotlin/JVM Tests to use JUnit

--- a/example/src/jvmTest/kotlin/io/github/kantis/mikrom/example/BookTest.kt
+++ b/example/src/jvmTest/kotlin/io/github/kantis/mikrom/example/BookTest.kt
@@ -1,5 +1,6 @@
 package io.github.kantis.mikrom.example
 
+import io.github.kantis.mikrom.Row
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -7,7 +8,7 @@ class BookTest : FunSpec(
    {
       test("Foo") {
          val book: Book = Book.RowMapper.mapRow(
-            mapOf(
+            Row.of(
                "author" to "JRR Tolkien",
                "title" to "The Fellowship of Mikrom",
                "numberOfPages" to 201,

--- a/example/src/jvmTest/kotlin/io/github/kantis/mikrom/example/BookTest.kt
+++ b/example/src/jvmTest/kotlin/io/github/kantis/mikrom/example/BookTest.kt
@@ -1,18 +1,22 @@
 package io.github.kantis.mikrom.example
 
+import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Row
+import io.github.kantis.mikrom.TypeConversions
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class BookTest : FunSpec(
    {
       test("Foo") {
+         val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
          val book: Book = Book.RowMapper.mapRow(
             Row.of(
                "author" to "JRR Tolkien",
                "title" to "The Fellowship of Mikrom",
                "numberOfPages" to 201,
             ),
+            mikrom,
          )
 
          book shouldBe Book("JRR Tolkien", "The Fellowship of Foo", 201)

--- a/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/fir/MikromFirDeclarationGenerationExtension.kt
+++ b/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/fir/MikromFirDeclarationGenerationExtension.kt
@@ -46,6 +46,13 @@ public class MikromFirDeclarationGenerationExtension(
       ).createConeType(session)
    }
 
+   private val mikromType by lazy {
+      ClassId(
+         FqName("io.github.kantis.mikrom"),
+         Name.identifier("Mikrom"),
+      ).createConeType(session)
+   }
+
    override fun FirDeclarationPredicateRegistrar.registerPredicates() {
       register(ROW_MAPPED_PREDICATE)
       register(HAS_ROW_MAPPED_PREDICATE)
@@ -134,6 +141,7 @@ public class MikromFirDeclarationGenerationExtension(
          returnType = key.ownerClassSymbol.constructType(),
       ) {
          valueParameter(Name.identifier("row"), rowType)
+         valueParameter(Name.identifier("mikrom"), mikromType)
       }
 
       return listOf(build.symbol)

--- a/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/fir/MikromFirDeclarationGenerationExtension.kt
+++ b/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/fir/MikromFirDeclarationGenerationExtension.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.SpecialNames
-import org.jetbrains.kotlin.name.StandardClassIds
 
 public class MikromFirDeclarationGenerationExtension(
    session: FirSession,
@@ -40,11 +39,11 @@ public class MikromFirDeclarationGenerationExtension(
          Name.identifier("RowMapper"),
       ).createConeType(session, typeArguments = arrayOf(typeArgument))
 
-   private val mapStringToAny by lazy {
-      StandardClassIds.Map.createConeType(
-         session,
-         typeArguments = arrayOf(session.builtinTypes.stringType.coneType, session.builtinTypes.anyType.coneType),
-      )
+   private val rowType by lazy {
+      ClassId(
+         FqName("io.github.kantis.mikrom"),
+         Name.identifier("Row"),
+      ).createConeType(session)
    }
 
    override fun FirDeclarationPredicateRegistrar.registerPredicates() {
@@ -134,7 +133,7 @@ public class MikromFirDeclarationGenerationExtension(
          name = callableId.callableName,
          returnType = key.ownerClassSymbol.constructType(),
       ) {
-         valueParameter(Name.identifier("row"), mapStringToAny)
+         valueParameter(Name.identifier("row"), rowType)
       }
 
       return listOf(build.symbol)

--- a/mikrom-compiler-plugin/testData/box/Person.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/Person.fir.ir.txt
@@ -58,31 +58,35 @@ FILE fqName:<root> fileName:/Person.kt
       FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] name:mapRow visibility:public modality:FINAL returnType:<root>.Person
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Person.RowMapper
         VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:row index:1 type:io.github.kantis.mikrom.Row
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:mikrom index:2 type:io.github.kantis.mikrom.Mikrom
         overridden:
-          public abstract fun mapRow (row: io.github.kantis.mikrom.Row): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper
+          public abstract fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper
         BLOCK_BODY
           VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:T of io.github.kantis.mikrom.Row.get [val]
             BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
-              CALL 'public final fun get <T> (column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
                 TYPE_ARG T: kotlin.String
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Person.RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Person.RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
                 ARG column: CONST String type=kotlin.String value="name"
                 ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
           VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:T of io.github.kantis.mikrom.Row.getOrNull? [val]
             BLOCK type=T of io.github.kantis.mikrom.Row.getOrNull? origin=null
-              CALL 'public final fun getOrNull <T> (column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.getOrNull? declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.getOrNull? origin=null
+              CALL 'public final fun getOrNull <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.getOrNull? declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.getOrNull? origin=null
                 TYPE_ARG T: kotlin.String
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Person.RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Person.RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
                 ARG column: CONST String type=kotlin.String value="nickname"
                 ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
           VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:T of io.github.kantis.mikrom.Row.get [val]
             BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
-              CALL 'public final fun get <T> (column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
                 TYPE_ARG T: kotlin.Int
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Person.RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Person.RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
                 ARG column: CONST String type=kotlin.String value="age"
                 ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.Int>
-          RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row): <root>.Person declared in <root>.Person.RowMapper'
+          RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.Person declared in <root>.Person.RowMapper'
             CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, nickname: kotlin.String?, age: kotlin.Int) declared in <root>.Person' type=<root>.Person origin=null
               ARG name: GET_VAR 'val tmp_0: T of io.github.kantis.mikrom.Row.get declared in <root>.Person.RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
               ARG nickname: GET_VAR 'val tmp_1: T of io.github.kantis.mikrom.Row.getOrNull? declared in <root>.Person.RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.getOrNull? origin=null
@@ -248,8 +252,15 @@ FILE fqName:<root> fileName:/Person.kt
             CONST String type=kotlin.String value=")"
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
+      VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+          ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
+            TYPE_ARG K: kotlin.reflect.KClass<*>
+            TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>
+          ARG conversions: CALL 'public final fun <get-EMPTY> (): io.github.kantis.mikrom.TypeConversions declared in io.github.kantis.mikrom.TypeConversions.Companion' type=io.github.kantis.mikrom.TypeConversions origin=GET_PROPERTY
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.TypeConversions.Companion
       VAR name:person type:<root>.Person [val]
-        CALL 'public final fun mapRow (row: io.github.kantis.mikrom.Row): <root>.Person declared in <root>.Person.RowMapper' type=<root>.Person origin=null
+        CALL 'public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.Person declared in <root>.Person.RowMapper' type=<root>.Person origin=null
           ARG <this>: GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.Person>]' type=<root>.Person.RowMapper
           ARG row: CALL 'public final fun of (vararg pairs: kotlin.Pair<kotlin.String, kotlin.Any?>): io.github.kantis.mikrom.Row declared in io.github.kantis.mikrom.Row.Companion' type=io.github.kantis.mikrom.Row origin=null
             ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.Row.Companion
@@ -269,6 +280,7 @@ FILE fqName:<root> fileName:/Person.kt
                 TYPE_ARG B: kotlin.Int
                 ARG <this>: CONST String type=kotlin.String value="age"
                 ARG that: CONST Int type=kotlin.Int value=-1
+          ARG mikrom: GET_VAR 'val mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.box' type=io.github.kantis.mikrom.Mikrom origin=null
       CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
         TYPE_ARG T: <root>.Person
         ARG expected: GET_VAR 'val person: <root>.Person declared in <root>.box' type=<root>.Person origin=null

--- a/mikrom-compiler-plugin/testData/box/Person.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/Person.fir.ir.txt
@@ -51,39 +51,42 @@ FILE fqName:<root> fileName:/Person.kt
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun hashCode (): kotlin.Int declared in io.github.kantis.mikrom.RowMapper
-      FUN FAKE_OVERRIDE name:mapRow visibility:public modality:ABSTRACT returnType:<root>.Person [fake_override]
-        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:io.github.kantis.mikrom.RowMapper<<root>.Person>
-        VALUE_PARAMETER kind:Regular name:row index:1 type:kotlin.collections.Map<kotlin.String, kotlin.Any?>
-        overridden:
-          public abstract fun mapRow (row: kotlin.collections.Map<kotlin.String, kotlin.Any?>): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper
       FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun toString (): kotlin.String declared in io.github.kantis.mikrom.RowMapper
       FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] name:mapRow visibility:public modality:FINAL returnType:<root>.Person
         VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Person.RowMapper
-        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:row index:1 type:kotlin.collections.Map<kotlin.String, kotlin.Any>
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:row index:1 type:io.github.kantis.mikrom.Row
+        overridden:
+          public abstract fun mapRow (row: io.github.kantis.mikrom.Row): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper
         BLOCK_BODY
-          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:V of kotlin.collections.Map? [val]
-            BLOCK type=V of kotlin.collections.Map? origin=null
-              CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=V of kotlin.collections.Map? origin=null
-                ARG <this>: GET_VAR 'row: kotlin.collections.Map<kotlin.String, kotlin.Any> declared in <root>.Person.RowMapper.mapRow' type=kotlin.collections.Map<kotlin.String, kotlin.Any> origin=null
-                ARG key: CONST String type=kotlin.String value="name"
-          VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:V of kotlin.collections.Map? [val]
-            BLOCK type=V of kotlin.collections.Map? origin=null
-              CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=V of kotlin.collections.Map? origin=null
-                ARG <this>: GET_VAR 'row: kotlin.collections.Map<kotlin.String, kotlin.Any> declared in <root>.Person.RowMapper.mapRow' type=kotlin.collections.Map<kotlin.String, kotlin.Any> origin=null
-                ARG key: CONST String type=kotlin.String value="nickname"
-          VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:V of kotlin.collections.Map? [val]
-            BLOCK type=V of kotlin.collections.Map? origin=null
-              CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=V of kotlin.collections.Map? origin=null
-                ARG <this>: GET_VAR 'row: kotlin.collections.Map<kotlin.String, kotlin.Any> declared in <root>.Person.RowMapper.mapRow' type=kotlin.collections.Map<kotlin.String, kotlin.Any> origin=null
-                ARG key: CONST String type=kotlin.String value="age"
-          RETURN type=kotlin.Nothing from='public final fun mapRow (row: kotlin.collections.Map<kotlin.String, kotlin.Any>): <root>.Person declared in <root>.Person.RowMapper'
+          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.String
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Person.RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG column: CONST String type=kotlin.String value="name"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+          VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:T of io.github.kantis.mikrom.Row.getOrNull? [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.getOrNull? origin=null
+              CALL 'public final fun getOrNull <T> (column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.getOrNull? declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.getOrNull? origin=null
+                TYPE_ARG T: kotlin.String
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Person.RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG column: CONST String type=kotlin.String value="nickname"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+          VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.Int
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Person.RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG column: CONST String type=kotlin.String value="age"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.Int>
+          RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row): <root>.Person declared in <root>.Person.RowMapper'
             CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, nickname: kotlin.String?, age: kotlin.Int) declared in <root>.Person' type=<root>.Person origin=null
-              ARG name: GET_VAR 'val tmp_0: V of kotlin.collections.Map? declared in <root>.Person.RowMapper.mapRow' type=V of kotlin.collections.Map? origin=null
-              ARG nickname: GET_VAR 'val tmp_1: V of kotlin.collections.Map? declared in <root>.Person.RowMapper.mapRow' type=V of kotlin.collections.Map? origin=null
-              ARG age: GET_VAR 'val tmp_2: V of kotlin.collections.Map? declared in <root>.Person.RowMapper.mapRow' type=V of kotlin.collections.Map? origin=null
+              ARG name: GET_VAR 'val tmp_0: T of io.github.kantis.mikrom.Row.get declared in <root>.Person.RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
+              ARG nickname: GET_VAR 'val tmp_1: T of io.github.kantis.mikrom.Row.getOrNull? declared in <root>.Person.RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.getOrNull? origin=null
+              ARG age: GET_VAR 'val tmp_2: T of io.github.kantis.mikrom.Row.get declared in <root>.Person.RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
     CONSTRUCTOR visibility:public returnType:<root>.Person [primary]
       VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
       VALUE_PARAMETER kind:Regular name:nickname index:1 type:kotlin.String?
@@ -246,12 +249,11 @@ FILE fqName:<root> fileName:/Person.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:person type:<root>.Person [val]
-        CALL 'public final fun mapRow (row: kotlin.collections.Map<kotlin.String, kotlin.Any>): <root>.Person declared in <root>.Person.RowMapper' type=<root>.Person origin=null
+        CALL 'public final fun mapRow (row: io.github.kantis.mikrom.Row): <root>.Person declared in <root>.Person.RowMapper' type=<root>.Person origin=null
           ARG <this>: GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.Person>]' type=<root>.Person.RowMapper
-          ARG row: CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<kotlin.String, kotlin.Any> origin=null
-            TYPE_ARG K: kotlin.String
-            TYPE_ARG V: kotlin.Any
-            ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlin.Any>> varargElementType=kotlin.Pair<kotlin.String, kotlin.Any>
+          ARG row: CALL 'public final fun of (vararg pairs: kotlin.Pair<kotlin.String, kotlin.Any?>): io.github.kantis.mikrom.Row declared in io.github.kantis.mikrom.Row.Companion' type=io.github.kantis.mikrom.Row origin=null
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.Row.Companion
+            ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlin.Any?>> varargElementType=kotlin.Pair<kotlin.String, kotlin.Any?>
               CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlin.String> origin=null
                 TYPE_ARG A: kotlin.String
                 TYPE_ARG B: kotlin.String

--- a/mikrom-compiler-plugin/testData/box/Person.fir.txt
+++ b/mikrom-compiler-plugin/testData/box/Person.fir.txt
@@ -1,6 +1,6 @@
 FILE: Person.kt
     public final fun box(): R|kotlin/String| {
-        lval person: R|Person| = Q|Person.RowMapper|.R|/Person.RowMapper.mapRow|(R|kotlin/collections/mapOf|<R|kotlin/String|, R|it(kotlin/Comparable<*> & java/io/Serializable)|>(vararg(String(name).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(Brian)), String(nickname).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(bnorm)), String(age).R|kotlin/to|<R|kotlin/String|, R|kotlin/Int|>(Int(-1)))))
+        lval person: R|Person| = Q|Person.RowMapper|.R|/Person.RowMapper.mapRow|(Q|io/github/kantis/mikrom/Row|.R|io/github/kantis/mikrom/Row.Companion.of|(vararg(String(name).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(Brian)), String(nickname).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(bnorm)), String(age).R|kotlin/to|<R|kotlin/String|, R|kotlin/Int|>(Int(-1)))))
         R|kotlin/test/assertEquals|<R|Person|>(R|<local>/person|, R|/Person.Person|(String(Brian), String(bnorm), Int(-1)))
         ^box String(OK)
     }
@@ -27,7 +27,7 @@ FILE: Person.kt
         public final fun copy(name: R|kotlin/String| = this@R|/Person|.R|/Person.name|, nickname: R|kotlin/String?| = this@R|/Person|.R|/Person.nickname|, age: R|kotlin/Int| = this@R|/Person|.R|/Person.age|): R|Person|
 
         public final object RowMapper : R|io/github/kantis/mikrom/RowMapper<Person>| {
-            public final fun mapRow(row: R|kotlin/collections/Map<kotlin/String, kotlin/Any>|): R|Person|
+            public final fun mapRow(row: R|io/github/kantis/mikrom/Row|): R|Person|
 
             private constructor(): R|Person.RowMapper|
 

--- a/mikrom-compiler-plugin/testData/box/Person.fir.txt
+++ b/mikrom-compiler-plugin/testData/box/Person.fir.txt
@@ -1,6 +1,7 @@
 FILE: Person.kt
     public final fun box(): R|kotlin/String| {
-        lval person: R|Person| = Q|Person.RowMapper|.R|/Person.RowMapper.mapRow|(Q|io/github/kantis/mikrom/Row|.R|io/github/kantis/mikrom/Row.Companion.of|(vararg(String(name).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(Brian)), String(nickname).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(bnorm)), String(age).R|kotlin/to|<R|kotlin/String|, R|kotlin/Int|>(Int(-1)))))
+        lval mikrom: R|io/github/kantis/mikrom/Mikrom| = R|io/github/kantis/mikrom/Mikrom.Mikrom|(R|kotlin/collections/mutableMapOf|<R|kotlin/reflect/KClass<*>|, R|io/github/kantis/mikrom/RowMapper<*>|>(), Q|io/github/kantis/mikrom/TypeConversions|.R|io/github/kantis/mikrom/TypeConversions.Companion.EMPTY|)
+        lval person: R|Person| = Q|Person.RowMapper|.R|/Person.RowMapper.mapRow|(Q|io/github/kantis/mikrom/Row|.R|io/github/kantis/mikrom/Row.Companion.of|(vararg(String(name).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(Brian)), String(nickname).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(bnorm)), String(age).R|kotlin/to|<R|kotlin/String|, R|kotlin/Int|>(Int(-1)))), R|<local>/mikrom|)
         R|kotlin/test/assertEquals|<R|Person|>(R|<local>/person|, R|/Person.Person|(String(Brian), String(bnorm), Int(-1)))
         ^box String(OK)
     }
@@ -27,7 +28,7 @@ FILE: Person.kt
         public final fun copy(name: R|kotlin/String| = this@R|/Person|.R|/Person.name|, nickname: R|kotlin/String?| = this@R|/Person|.R|/Person.nickname|, age: R|kotlin/Int| = this@R|/Person|.R|/Person.age|): R|Person|
 
         public final object RowMapper : R|io/github/kantis/mikrom/RowMapper<Person>| {
-            public final fun mapRow(row: R|io/github/kantis/mikrom/Row|): R|Person|
+            public final fun mapRow(row: R|io/github/kantis/mikrom/Row|, mikrom: R|io/github/kantis/mikrom/Mikrom|): R|Person|
 
             private constructor(): R|Person.RowMapper|
 

--- a/mikrom-compiler-plugin/testData/box/Person.kt
+++ b/mikrom-compiler-plugin/testData/box/Person.kt
@@ -1,12 +1,13 @@
 // FIR_DUMP
 // DUMP_IR
 
+import io.github.kantis.mikrom.Row
 import io.github.kantis.mikrom.generator.RowMapped
 import kotlin.test.*
 
 fun box(): String {
    val person = Person.RowMapper.mapRow(
-      mapOf(
+      Row.of(
          "name" to "Brian",
          "nickname" to "bnorm",
          "age" to -1,

--- a/mikrom-compiler-plugin/testData/box/Person.kt
+++ b/mikrom-compiler-plugin/testData/box/Person.kt
@@ -1,17 +1,21 @@
 // FIR_DUMP
 // DUMP_IR
 
+import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Row
+import io.github.kantis.mikrom.TypeConversions
 import io.github.kantis.mikrom.generator.RowMapped
 import kotlin.test.*
 
 fun box(): String {
+   val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
    val person = Person.RowMapper.mapRow(
       Row.of(
          "name" to "Brian",
          "nickname" to "bnorm",
          "age" to -1,
       ),
+      mikrom,
    )
 
    assertEquals(person, Person("Brian", "bnorm", -1))

--- a/mikrom/mikrom-core/api/mikrom-core.api
+++ b/mikrom/mikrom-core/api/mikrom-core.api
@@ -1,6 +1,17 @@
+public final class io/github/kantis/mikrom/DefaultConversionsKt {
+	public static final fun commonDefaultConversions ()Lio/github/kantis/mikrom/TypeConversions;
+	public static final fun defaultConversions ()Lio/github/kantis/mikrom/TypeConversions;
+}
+
+public final class io/github/kantis/mikrom/DefaultConversions_jvmKt {
+	public static final fun platformDefaultConversions ()Lio/github/kantis/mikrom/TypeConversions;
+}
+
 public final class io/github/kantis/mikrom/Mikrom {
 	public static final field Companion Lio/github/kantis/mikrom/Mikrom$Companion;
-	public fun <init> (Ljava/util/Map;)V
+	public fun <init> (Ljava/util/Map;Lio/github/kantis/mikrom/TypeConversions;)V
+	public synthetic fun <init> (Ljava/util/Map;Lio/github/kantis/mikrom/TypeConversions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getConversions ()Lio/github/kantis/mikrom/TypeConversions;
 	public final fun getRowMappers ()Ljava/util/Map;
 }
 
@@ -11,6 +22,7 @@ public final class io/github/kantis/mikrom/Mikrom$Companion {
 public final class io/github/kantis/mikrom/MikromBuilder {
 	public fun <init> ()V
 	public final fun build ()Lio/github/kantis/mikrom/Mikrom;
+	public final fun getConversionsBuilder ()Lio/github/kantis/mikrom/TypeConversions$Builder;
 	public final fun getRowMappers ()Ljava/util/Map;
 }
 
@@ -50,9 +62,9 @@ public final class io/github/kantis/mikrom/Row {
 	public static final field Companion Lio/github/kantis/mikrom/Row$Companion;
 	public fun <init> (Ljava/util/Map;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun get (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public final fun get (Lio/github/kantis/mikrom/Mikrom;Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 	public final fun getColumnNames ()Ljava/util/Set;
-	public final fun getOrNull (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public final fun getOrNull (Lio/github/kantis/mikrom/Mikrom;Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
 	public fun hashCode ()I
 	public final fun singleValue ()Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
@@ -90,7 +102,37 @@ public final class io/github/kantis/mikrom/RowBuilderKt {
 }
 
 public abstract interface class io/github/kantis/mikrom/RowMapper {
-	public abstract fun mapRow (Lio/github/kantis/mikrom/Row;)Ljava/lang/Object;
+	public abstract fun mapRow (Lio/github/kantis/mikrom/Row;Lio/github/kantis/mikrom/Mikrom;)Ljava/lang/Object;
+}
+
+public final class io/github/kantis/mikrom/TypeConversions {
+	public static final field Companion Lio/github/kantis/mikrom/TypeConversions$Companion;
+	public fun <init> (Ljava/util/Map;)V
+	public final fun convert (Ljava/lang/Object;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public final fun plus (Lio/github/kantis/mikrom/TypeConversions;)Lio/github/kantis/mikrom/TypeConversions;
+}
+
+public final class io/github/kantis/mikrom/TypeConversions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lio/github/kantis/mikrom/TypeConversions;
+	public final fun getConversions ()Ljava/util/Map;
+}
+
+public final class io/github/kantis/mikrom/TypeConversions$Companion {
+	public final fun getEMPTY ()Lio/github/kantis/mikrom/TypeConversions;
+}
+
+public final class io/github/kantis/mikrom/TypeConversions$ConversionKey {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
+	public final fun component1 ()Lkotlin/reflect/KClass;
+	public final fun component2 ()Lkotlin/reflect/KClass;
+	public final fun copy (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)Lio/github/kantis/mikrom/TypeConversions$ConversionKey;
+	public static synthetic fun copy$default (Lio/github/kantis/mikrom/TypeConversions$ConversionKey;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lio/github/kantis/mikrom/TypeConversions$ConversionKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSource ()Lkotlin/reflect/KClass;
+	public final fun getTarget ()Lkotlin/reflect/KClass;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/github/kantis/mikrom/TypeMismatchException : java/lang/RuntimeException {

--- a/mikrom/mikrom-core/api/mikrom-core.api
+++ b/mikrom/mikrom-core/api/mikrom-core.api
@@ -46,8 +46,55 @@ public final class io/github/kantis/mikrom/Rollback {
 	public static final field INSTANCE Lio/github/kantis/mikrom/Rollback;
 }
 
+public final class io/github/kantis/mikrom/Row {
+	public static final field Companion Lio/github/kantis/mikrom/Row$Companion;
+	public fun <init> (Ljava/util/Map;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public final fun getColumnNames ()Ljava/util/Set;
+	public final fun getOrNull (Ljava/lang/String;Lkotlin/reflect/KClass;)Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun singleValue ()Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kantis/mikrom/Row$Column {
+	public fun <init> (Ljava/lang/Object;Lkotlin/reflect/KClass;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/reflect/KClass;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lkotlin/reflect/KClass;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Object;Lkotlin/reflect/KClass;Ljava/lang/String;)Lio/github/kantis/mikrom/Row$Column;
+	public static synthetic fun copy$default (Lio/github/kantis/mikrom/Row$Column;Ljava/lang/Object;Lkotlin/reflect/KClass;Ljava/lang/String;ILjava/lang/Object;)Lio/github/kantis/mikrom/Row$Column;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKotlinType ()Lkotlin/reflect/KClass;
+	public final fun getSqlTypeName ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/kantis/mikrom/Row$Companion {
+	public final fun of ([Lkotlin/Pair;)Lio/github/kantis/mikrom/Row;
+}
+
+public final class io/github/kantis/mikrom/RowBuilder {
+	public fun <init> ()V
+	public final fun column (Ljava/lang/String;Ljava/lang/Object;Lkotlin/reflect/KClass;Ljava/lang/String;)V
+	public static synthetic fun column$default (Lio/github/kantis/mikrom/RowBuilder;Ljava/lang/String;Ljava/lang/Object;Lkotlin/reflect/KClass;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun getColumns ()Ljava/util/Map;
+}
+
+public final class io/github/kantis/mikrom/RowBuilderKt {
+	public static final fun buildRow (Lkotlin/jvm/functions/Function1;)Lio/github/kantis/mikrom/Row;
+}
+
 public abstract interface class io/github/kantis/mikrom/RowMapper {
-	public abstract fun mapRow (Ljava/util/Map;)Ljava/lang/Object;
+	public abstract fun mapRow (Lio/github/kantis/mikrom/Row;)Ljava/lang/Object;
+}
+
+public final class io/github/kantis/mikrom/TypeMismatchException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
 }
 
 public abstract interface class io/github/kantis/mikrom/datasource/DataSource {

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/DefaultConversions.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/DefaultConversions.kt
@@ -1,0 +1,14 @@
+package io.github.kantis.mikrom
+
+public fun commonDefaultConversions(): TypeConversions =
+   TypeConversions.Builder().apply {
+      register<Int, UInt> { it.toUInt() }
+      register<Int, UByte> { it.toUByte() }
+      register<Int, UShort> { it.toUShort() }
+      register<Int, Byte> { it.toByte() }
+      register<Int, Short> { it.toShort() }
+   }.build()
+
+public expect fun platformDefaultConversions(): TypeConversions
+
+public fun defaultConversions(): TypeConversions = commonDefaultConversions() + platformDefaultConversions()

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/Mikrom.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/Mikrom.kt
@@ -5,6 +5,7 @@ import kotlin.reflect.KClass
 
 public class Mikrom(
    public val rowMappers: MutableMap<KClass<*>, RowMapper<*>>,
+   public val conversions: TypeConversions = defaultConversions(),
 ) {
    @Suppress("UNCHECKED_CAST")
    public inline fun <reified T : Any> resolveRowMapper(): RowMapper<T> =

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/MikromBuilder.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/MikromBuilder.kt
@@ -12,6 +12,10 @@ public class MikromBuilder {
       rowMappers[T::class] = mapper
    }
 
+   public inline fun <reified T> registerRowMapper(noinline mapper: context(Mikrom) (Row) -> T) {
+      rowMappers[T::class] = RowMapper { row, mikrom -> mapper(mikrom, row) }
+   }
+
    public inline fun <reified S : Any, reified T : Any> registerConversion(noinline conversion: (S) -> T) {
       conversionsBuilder.register(conversion)
    }

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/MikromBuilder.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/MikromBuilder.kt
@@ -5,9 +5,16 @@ import kotlin.reflect.KClass
 public class MikromBuilder {
    public val rowMappers: MutableMap<KClass<*>, RowMapper<*>> = mutableMapOf()
 
+   @PublishedApi
+   internal val conversionsBuilder: TypeConversions.Builder = TypeConversions.Builder()
+
    public inline fun <reified T> registerRowMapper(mapper: RowMapper<T>) {
-      rowMappers.put(T::class, mapper)
+      rowMappers[T::class] = mapper
    }
 
-   public fun build(): Mikrom = Mikrom(rowMappers)
+   public inline fun <reified S : Any, reified T : Any> registerConversion(noinline conversion: (S) -> T) {
+      conversionsBuilder.register(conversion)
+   }
+
+   public fun build(): Mikrom = Mikrom(rowMappers, defaultConversions() + conversionsBuilder.build())
 }

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/Row.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/Row.kt
@@ -1,3 +1,145 @@
 package io.github.kantis.mikrom
 
-public typealias Row = Map<String, Any?>
+import java.sql.Timestamp
+import java.time.Instant
+import kotlin.reflect.KClass
+
+public class Row
+   @PublishedApi
+   internal constructor(private val columns: Map<String, Column>) {
+      public data class Column(
+         val value: Any?,
+         val kotlinType: KClass<*>? = null,
+         val sqlTypeName: String? = null,
+      )
+
+      public val columnNames: Set<String> get() = columns.keys
+
+      public fun singleValue(): Any? {
+         require(columns.size == 1) {
+            "Expected exactly one column, but found ${columns.size}: $columnNames"
+         }
+         return columns.values.single().value
+      }
+
+      private fun resolveColumn(column: String): Column =
+         columns[column]
+            ?: throw NoSuchElementException(
+               "Column '$column' not found. Available: $columnNames",
+            )
+
+      private fun typeMismatchMessage(
+         column: String,
+         col: Column,
+         actual: String,
+         expected: String,
+      ): String {
+         val typeInfo = col.sqlTypeName?.let { " ($it)" } ?: ""
+         return "Column '$column'$typeInfo contains $actual, " +
+            "cannot be read as $expected"
+      }
+
+      public fun <T : Any> get(
+         column: String,
+         clazz: KClass<*>,
+      ): T {
+         val col = resolveColumn(column)
+
+         val value = col.value
+            ?: throw TypeMismatchException(
+               "Column '$column' is null, " +
+                  "but non-null ${clazz.simpleName} was expected",
+            )
+
+         val coercedValue = (TypeCoercer.coerce(value, clazz) as? T) ?: value
+
+         return coercedValue as? T
+            ?: throw TypeMismatchException(
+               typeMismatchMessage(
+                  column,
+                  col,
+                  value::class.simpleName ?: "Unknown",
+                  clazz.simpleName ?: "Unknown",
+               ),
+            )
+      }
+
+      public fun <T> getOrNull(
+         column: String,
+         clazz: KClass<*>,
+      ): T? {
+         val col = resolveColumn(column)
+         val value = col.value ?: return null
+         val coercedValue = (TypeCoercer.coerce(value, clazz) as? T) ?: value
+
+         return coercedValue as? T
+            ?: throw TypeMismatchException(
+               typeMismatchMessage(
+                  column,
+                  col,
+                  value::class.simpleName ?: "Unknown",
+                  clazz.simpleName ?: "Unknown",
+               ),
+            )
+      }
+
+      override fun equals(other: Any?): Boolean {
+         if (this === other) return true
+         if (other !is Row) return false
+         return columns == other.columns
+      }
+
+      override fun hashCode(): Int = columns.hashCode()
+
+      override fun toString(): String = "Row(${columns.entries.joinToString { "${it.key}=${it.value.value}" }})"
+
+      public companion object {
+         public fun of(vararg pairs: Pair<String, Any?>): Row =
+            Row(
+               pairs.associate { (name, value) ->
+                  name to Column(value)
+               },
+            )
+      }
+   }
+
+public inline fun <reified T : Any> Row.get(column: String): T = get(column, T::class)
+
+public inline fun <reified T> Row.getOrNull(column: String): T? = getOrNull(column, T::class)
+
+internal object TypeCoercer {
+   fun coerce(
+      value: Any,
+      target: KClass<*>,
+   ): Any? =
+      when (value) {
+         is Int -> coerceInt(value, target)
+
+         // TODO: JVM-only code in commonMain
+//         is Timestamp -> coerceTimestamp(value, target)
+
+         else -> null
+      }
+
+   fun coerceTimestamp(
+      value: Timestamp,
+      target: KClass<*>,
+   ): Any? =
+      when (target) {
+         Instant::class -> value.toInstant()
+         else -> null
+      }
+
+   fun coerceInt(
+      value: Int,
+      target: KClass<*>,
+   ): Any? =
+      when (target) {
+         UInt::class -> value.toUInt()
+         UByte::class -> value.toUByte()
+         UShort::class -> value.toUShort()
+         Byte::class -> value.toByte()
+         Short::class -> value.toShort()
+         else -> null
+      }
+}

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/RowBuilder.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/RowBuilder.kt
@@ -1,0 +1,25 @@
+package io.github.kantis.mikrom
+
+import kotlin.reflect.KClass
+
+public class RowBuilder
+   @PublishedApi
+   internal constructor() {
+      @PublishedApi
+      internal val columns: MutableMap<String, Row.Column> = mutableMapOf()
+
+      public fun column(
+         name: String,
+         value: Any?,
+         kotlinType: KClass<*>? = null,
+         sqlTypeName: String? = null,
+      ) {
+         columns[name] = Row.Column(value, kotlinType, sqlTypeName)
+      }
+   }
+
+public inline fun buildRow(block: RowBuilder.() -> Unit): Row {
+   val builder = RowBuilder()
+   builder.block()
+   return Row(builder.columns.toMap())
+}

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/RowMapper.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/RowMapper.kt
@@ -1,5 +1,8 @@
 package io.github.kantis.mikrom
 
 public fun interface RowMapper<out T> {
-   public fun mapRow(row: Row): T
+   public fun mapRow(
+      row: Row,
+      mikrom: Mikrom,
+   ): T
 }

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/TypeConversions.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/TypeConversions.kt
@@ -1,0 +1,32 @@
+package io.github.kantis.mikrom
+
+import kotlin.reflect.KClass
+
+public class TypeConversions(
+   private val conversions: Map<ConversionKey, (Any) -> Any>,
+) {
+   public data class ConversionKey(val source: KClass<*>, val target: KClass<*>)
+
+   public fun convert(
+      value: Any,
+      target: KClass<*>,
+   ): Any? = conversions[ConversionKey(value::class, target)]?.invoke(value)
+
+   public operator fun plus(other: TypeConversions): TypeConversions = TypeConversions(conversions + other.conversions)
+
+   public companion object {
+      public val EMPTY: TypeConversions = TypeConversions(emptyMap())
+   }
+
+   public class Builder {
+      @PublishedApi
+      internal val conversions: MutableMap<ConversionKey, (Any) -> Any> = mutableMapOf()
+
+      @Suppress("UNCHECKED_CAST")
+      public inline fun <reified S : Any, reified T : Any> register(noinline conversion: (S) -> T) {
+         conversions[ConversionKey(S::class, T::class)] = conversion as (Any) -> Any
+      }
+
+      public fun build(): TypeConversions = TypeConversions(conversions.toMap())
+   }
+}

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/TypeMismatchException.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/TypeMismatchException.kt
@@ -1,0 +1,3 @@
+package io.github.kantis.mikrom
+
+public class TypeMismatchException(message: String) : RuntimeException(message)

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/primitives.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/primitives.kt
@@ -1,5 +1,6 @@
 package io.github.kantis.mikrom
 
+import java.math.BigDecimal
 import kotlin.reflect.KClass
 
 public val nonMappedPrimitives: Set<KClass<*>> = setOf(
@@ -9,4 +10,5 @@ public val nonMappedPrimitives: Set<KClass<*>> = setOf(
    Float::class,
    Double::class,
    Boolean::class,
+   BigDecimal::class,
 )

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/queries.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/queries.kt
@@ -8,7 +8,7 @@ public inline fun <reified T> Mikrom.queryForSingleOrNull(query: Query): T? = nu
 context(Transaction)
 public inline fun <reified T : Any> Mikrom.queryFor(query: Query): List<T> {
    if (T::class in nonMappedPrimitives) {
-      return query(query).map { it.values.single() as T }
+      return query(query).map { it.singleValue() as T }
    }
    val rowMapper = resolveRowMapper<T>()
    return query(query).map(rowMapper::mapRow)
@@ -26,7 +26,7 @@ public inline fun <reified T : Any> Mikrom.queryFor(
    params: List<Any>,
 ): List<T> {
    if (T::class in nonMappedPrimitives) {
-      return query(query, params).map { it.values.single() as T }
+      return query(query, params).map { it.singleValue() as T }
    }
    val rowMapper = resolveRowMapper<T>()
    return query(query, params).map(rowMapper::mapRow)

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/queryFor.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/queryFor.kt
@@ -9,10 +9,10 @@ import kotlinx.coroutines.flow.map
 context(SuspendingTransaction)
 public suspend inline fun <reified T : Any> Mikrom.queryFor(query: Query): Flow<T> {
    if (T::class in nonMappedPrimitives) {
-      return query(query).map { it.values.single() as T }
+      return query(query).map { it.singleValue() as T }
    }
    val rowMapper = resolveRowMapper<T>()
-   return query(query).map(rowMapper::mapRow)
+   return query(query).map { rowMapper.mapRow(it) }
 }
 
 context(SuspendingTransaction)
@@ -27,8 +27,8 @@ public suspend inline fun <reified T : Any> Mikrom.queryFor(
    params: List<Any>,
 ): Flow<T> {
    if (T::class in nonMappedPrimitives) {
-      return query(query, params).map { it.values.single() as T }
+      return query(query, params).map { it.singleValue() as T }
    }
    val rowMapper = resolveRowMapper<T>()
-   return query(query, params).map(rowMapper::mapRow)
+   return query(query, params).map { rowMapper.mapRow(it) }
 }

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/queryFor.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/queryFor.kt
@@ -6,29 +6,29 @@ import io.github.kantis.mikrom.nonMappedPrimitives
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-context(SuspendingTransaction)
+context(transaction: SuspendingTransaction)
 public suspend inline fun <reified T : Any> Mikrom.queryFor(query: Query): Flow<T> {
    if (T::class in nonMappedPrimitives) {
-      return query(query).map { it.singleValue() as T }
+      return transaction.query(query).map { it.singleValue() as T }
    }
    val rowMapper = resolveRowMapper<T>()
-   return query(query).map { rowMapper.mapRow(it) }
+   return transaction.query(query).map { rowMapper.mapRow(it, this@queryFor) }
 }
 
-context(SuspendingTransaction)
+context(transaction: SuspendingTransaction)
 public suspend inline fun <reified T> Mikrom.queryFor(
    query: Query,
    param: Any,
 ): Flow<T> = queryFor(query, listOf(param))
 
-context(SuspendingTransaction)
+context(transaction: SuspendingTransaction)
 public suspend inline fun <reified T : Any> Mikrom.queryFor(
    query: Query,
    params: List<Any>,
 ): Flow<T> {
    if (T::class in nonMappedPrimitives) {
-      return query(query, params).map { it.singleValue() as T }
+      return transaction.query(query, params).map { it.singleValue() as T }
    }
    val rowMapper = resolveRowMapper<T>()
-   return query(query, params).map { rowMapper.mapRow(it) }
+   return transaction.query(query, params).map { rowMapper.mapRow(it, this@queryFor) }
 }

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/suspendQueries.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/suspendQueries.kt
@@ -6,38 +6,38 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlin.collections.emptyList
 
-context(SuspendingTransaction)
+context(transaction: SuspendingTransaction)
 public suspend inline fun Mikrom.execute(
    query: Query,
    params: List<Any>,
 ) {
-   executeInTransaction(query, params)
+   transaction.executeInTransaction(query, params)
 }
 
-context(SuspendingTransaction)
+context(transaction: SuspendingTransaction)
 public suspend fun <T : Any> Mikrom.execute(
    query: Query,
    vararg params: T,
 ) {
    params.forEach {
       if (it is List<*>)
-         executeInTransaction(query, it)
+         transaction.executeInTransaction(query, it)
       else
-         executeInTransaction(query, listOf(it))
+         transaction.executeInTransaction(query, listOf(it))
    }
 }
 
-context(SuspendingTransaction)
+context(transaction: SuspendingTransaction)
 public suspend fun Mikrom.execute(query: Query) {
-   executeInTransaction(query, emptyList<Any>())
+   transaction.executeInTransaction(query, emptyList<Any>())
 }
 
 /**
  * Allows streaming parameters for big inserts/updates.
  * Returns a [Job] that can be used to cancel the operation or await its completion.
  */
-context(SuspendingTransaction)
+context(transaction: SuspendingTransaction)
 public suspend fun Mikrom.executeStreaming(
    query: Query,
    params: Flow<List<Any>>,
-): Job = executeInTransaction(query, params)
+): Job = transaction.executeInTransaction(query, params)

--- a/mikrom/mikrom-core/src/commonTest/kotlin/io/github/kantis/mikrom/MikromTest.kt
+++ b/mikrom/mikrom-core/src/commonTest/kotlin/io/github/kantis/mikrom/MikromTest.kt
@@ -10,25 +10,25 @@ class MikromTest : FunSpec({
    test("Resolve mapper") {
       val mikrom =
          Mikrom {
-            registerRowMapper { row -> Foo(row["bar"] as String) }
+            registerRowMapper { row -> Foo(row.get("bar")) }
          }
 
       mikrom
          .resolveRowMapper<Foo>()
-         .mapRow(mapOf("bar" to "baz")) shouldBe Foo("baz")
+         .mapRow(Row.of("bar" to "baz")) shouldBe Foo("baz")
    }
 
    test("integrate with data sources") {
       val mikrom =
          Mikrom {
-            registerRowMapper { row -> Foo(row["bar"] as String) }
+            registerRowMapper { row -> Foo(row.get("bar")) }
          }
 
       val dataSource =
          InMemoryDataSource(
             listOf(
-               mapOf("bar" to "baz"),
-               mapOf("bar" to "qux"),
+               Row.of("bar" to "baz"),
+               Row.of("bar" to "qux"),
             ),
          )
 

--- a/mikrom/mikrom-core/src/commonTest/kotlin/io/github/kantis/mikrom/MikromTest.kt
+++ b/mikrom/mikrom-core/src/commonTest/kotlin/io/github/kantis/mikrom/MikromTest.kt
@@ -10,7 +10,7 @@ class MikromTest : FunSpec({
    test("Resolve mapper") {
       val mikrom =
          Mikrom {
-            registerRowMapper<Foo> { row, mikrom -> with(mikrom) { Foo(row.get("bar")) } }
+            registerRowMapper<Foo> { row -> Foo(row.get("bar")) }
          }
 
       mikrom
@@ -21,7 +21,7 @@ class MikromTest : FunSpec({
    test("integrate with data sources") {
       val mikrom =
          Mikrom {
-            registerRowMapper<Foo> { row, mikrom -> with(mikrom) { Foo(row.get("bar")) } }
+            registerRowMapper<Foo> { row -> Foo(row.get("bar")) }
          }
 
       val dataSource =

--- a/mikrom/mikrom-core/src/commonTest/kotlin/io/github/kantis/mikrom/MikromTest.kt
+++ b/mikrom/mikrom-core/src/commonTest/kotlin/io/github/kantis/mikrom/MikromTest.kt
@@ -10,18 +10,18 @@ class MikromTest : FunSpec({
    test("Resolve mapper") {
       val mikrom =
          Mikrom {
-            registerRowMapper { row -> Foo(row.get("bar")) }
+            registerRowMapper<Foo> { row, mikrom -> with(mikrom) { Foo(row.get("bar")) } }
          }
 
       mikrom
          .resolveRowMapper<Foo>()
-         .mapRow(Row.of("bar" to "baz")) shouldBe Foo("baz")
+         .mapRow(Row.of("bar" to "baz"), mikrom) shouldBe Foo("baz")
    }
 
    test("integrate with data sources") {
       val mikrom =
          Mikrom {
-            registerRowMapper { row -> Foo(row.get("bar")) }
+            registerRowMapper<Foo> { row, mikrom -> with(mikrom) { Foo(row.get("bar")) } }
          }
 
       val dataSource =

--- a/mikrom/mikrom-core/src/jsMain/kotlin/io/github/kantis/mikrom/DefaultConversions.js.kt
+++ b/mikrom/mikrom-core/src/jsMain/kotlin/io/github/kantis/mikrom/DefaultConversions.js.kt
@@ -1,0 +1,3 @@
+package io.github.kantis.mikrom
+
+public actual fun platformDefaultConversions(): TypeConversions = TypeConversions.EMPTY

--- a/mikrom/mikrom-core/src/jvmMain/kotlin/io/github/kantis/mikrom/DefaultConversions.jvm.kt
+++ b/mikrom/mikrom-core/src/jvmMain/kotlin/io/github/kantis/mikrom/DefaultConversions.jvm.kt
@@ -1,0 +1,9 @@
+package io.github.kantis.mikrom
+
+import java.sql.Timestamp
+import java.time.Instant
+
+public actual fun platformDefaultConversions(): TypeConversions =
+   TypeConversions.Builder().apply {
+      register<Timestamp, Instant> { it.toInstant() }
+   }.build()

--- a/mikrom/mikrom-jdbc/src/jvmMain/kotlin/JdbcTransaction.kt
+++ b/mikrom/mikrom-jdbc/src/jvmMain/kotlin/JdbcTransaction.kt
@@ -3,10 +3,12 @@ package io.github.kantis.mikrom.jdbc
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.Row
 import io.github.kantis.mikrom.datasource.Transaction
+import java.math.BigDecimal
 import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.Timestamp
 import java.sql.Types
+import java.time.Instant
 import java.time.LocalDateTime
 
 public class JdbcTransaction(private val connection: Connection) : Transaction {
@@ -50,6 +52,8 @@ public class JdbcTransaction(private val connection: Connection) : Transaction {
             is Boolean -> statement.setBoolean(index + 1, param)
             is ByteArray -> statement.setBytes(index + 1, param)
             is LocalDateTime -> statement.setTimestamp(index + 1, Timestamp.valueOf(param))
+            is BigDecimal -> statement.setBigDecimal(index + 1, param)
+            is Instant -> statement.setTimestamp(index + 1, Timestamp.from(param))
             null -> statement.setNull(index + 1, Types.NULL)
             else -> error("Unsupported parameter type: ${param::class.simpleName} at index ${index + 1} with value $param")
          }

--- a/mikrom/mikrom-jdbc/src/jvmMain/kotlin/ResultSetReader.kt
+++ b/mikrom/mikrom-jdbc/src/jvmMain/kotlin/ResultSetReader.kt
@@ -2,6 +2,7 @@ package io.github.kantis.mikrom.jdbc
 
 import io.github.kantis.mikrom.MikromInternal
 import io.github.kantis.mikrom.Row
+import io.github.kantis.mikrom.buildRow
 import java.sql.ResultSet
 import java.sql.Types
 
@@ -21,31 +22,49 @@ public object ResultSetReader {
    }
 
    private fun loadRow(resultSet: ResultSet): Row {
-      val row = mutableMapOf<String, Any?>()
       val metaData = resultSet.metaData
-      for (i in 1..metaData.columnCount) {
-         val columnName = metaData.getColumnName(i)
-         println("Reading column $i: $columnName")
-         val columnType = resultSet.metaData.getColumnType(i)
-         val value = when (columnType) {
-            Types.BIT,
-            Types.TINYINT,
-            Types.SMALLINT,
-            Types.INTEGER,
-            Types.BIGINT,
-            -> resultSet.getInt(i)
-            Types.VARCHAR -> resultSet.getString(i)
-            Types.BOOLEAN -> resultSet.getBoolean(i)
-            Types.DATE -> resultSet.getDate(i)
-            Types.TIME -> resultSet.getTime(i)
-            Types.TIME_WITH_TIMEZONE -> TODO("TIME_WITH_TIMEZONE is not supported yet")
-            Types.TIMESTAMP -> resultSet.getTimestamp(i)
-            Types.TIMESTAMP_WITH_TIMEZONE -> TODO("TIMESTAMP_WITH_TIMEZONE is not supported yet")
-            else -> error("Column $i is of unsupported type $columnType")
-         }
+      return buildRow {
+         for (i in 1..metaData.columnCount) {
+            val columnName = metaData.getColumnName(i)
+            val columnType = metaData.getColumnType(i)
+            val sqlTypeName = metaData.getColumnTypeName(i)
+            val value = when (columnType) {
+               Types.BIT,
+               Types.TINYINT,
+               Types.SMALLINT,
+               Types.INTEGER,
+               Types.BIGINT,
+               -> resultSet.getInt(i)
 
-         row[columnName] = value
+               Types.DECIMAL -> resultSet.getBigDecimal(i)
+
+               Types.VARCHAR -> resultSet.getString(i)
+
+               Types.BOOLEAN -> resultSet.getBoolean(i)
+
+               Types.DATE -> resultSet.getDate(i)
+
+               Types.TIME -> resultSet.getTime(i)
+
+               Types.TIME_WITH_TIMEZONE -> TODO("TIME_WITH_TIMEZONE is not supported yet")
+
+               Types.TIMESTAMP -> resultSet.getTimestamp(i)
+
+               Types.TIMESTAMP_WITH_TIMEZONE -> TODO("TIMESTAMP_WITH_TIMEZONE is not supported yet")
+
+               else -> error("Column $i is of unsupported type $columnType")
+            }
+
+            val kotlinType = when (columnType) {
+               Types.BIT, Types.TINYINT, Types.SMALLINT, Types.INTEGER, Types.BIGINT -> Int::class
+               Types.VARCHAR -> String::class
+               Types.BOOLEAN -> Boolean::class
+               Types.TIMESTAMP -> java.sql.Timestamp::class
+               else -> null
+            }
+
+            column(columnName, value, kotlinType, sqlTypeName)
+         }
       }
-      return row
    }
 }

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/DataTypesTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/DataTypesTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 class DataTypesTest : FunSpec({
    val dataSource = prepareH2Database(
@@ -27,24 +28,25 @@ class DataTypesTest : FunSpec({
    val mikrom = Mikrom { }
 
    test("Mixing null as a parameter should work") {
-      val now = Instant.now()
+      val now = Instant.now().truncatedTo(ChronoUnit.MILLIS)
 
       dataSource.transaction {
          mikrom.execute(
             Query("INSERT INTO foo (bar, number, timestamp) VALUES (?, ?, ?)"),
-            listOf("baz", "123.01".toBigDecimal(), now),
             listOf(null, null, null),
          )
 
          val result = query(Query("SELECT * FROM foo"))
 
-         result.size shouldBe 2
-         result[0].get<Int>("id") shouldBe 1
-         result[0].get<String>("bar") shouldBe "baz"
-         result[0].get<BigDecimal>("number") shouldBe "123.01".toBigDecimal()
-         result[0].get<Instant>("timestamp") shouldBeEqual now
-         result[1].get<Int>("id") shouldBe 2
-         result[1].getOrNull<String>("bar") shouldBe null
+         with(mikrom) {
+            result.size shouldBe 2
+            result[0].get<Int>("id") shouldBe 1
+            result[0].get<String>("bar") shouldBe "baz"
+            result[0].get<BigDecimal>("number") shouldBe "123.01".toBigDecimal()
+            result[0].get<Instant>("timestamp") shouldBeEqual now
+            result[1].get<Int>("id") shouldBe 2
+            result[1].getOrNull<String>("bar") shouldBe null
+         }
       }
    }
 })

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/DataTypesTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/DataTypesTest.kt
@@ -33,6 +33,7 @@ class DataTypesTest : FunSpec({
       dataSource.transaction {
          mikrom.execute(
             Query("INSERT INTO foo (bar, number, timestamp) VALUES (?, ?, ?)"),
+            listOf("baz", "123.01".toBigDecimal(), now),
             listOf(null, null, null),
          )
 

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/DataTypesTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/DataTypesTest.kt
@@ -3,16 +3,23 @@ package io.github.kantis.mikrom.jdbc
 import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.execute
+import io.github.kantis.mikrom.get
+import io.github.kantis.mikrom.getOrNull
 import io.github.kantis.mikrom.jdbc.h2.prepareH2Database
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+import java.time.Instant
 
 class DataTypesTest : FunSpec({
    val dataSource = prepareH2Database(
       """
          CREATE TABLE foo(
            id INT PRIMARY KEY AUTO_INCREMENT,
-           bar VARCHAR(255)
+           bar VARCHAR(255),
+           number DECIMAL(10,2),
+           timestamp TIMESTAMP
          );
       """.trimIndent(),
    )
@@ -20,19 +27,24 @@ class DataTypesTest : FunSpec({
    val mikrom = Mikrom { }
 
    test("Mixing null as a parameter should work") {
+      val now = Instant.now()
+
       dataSource.transaction {
          mikrom.execute(
-            Query("INSERT INTO foo (bar) VALUES (?)"),
-            listOf("baz"),
-            listOf(null),
+            Query("INSERT INTO foo (bar, number, timestamp) VALUES (?, ?, ?)"),
+            listOf("baz", "123.01".toBigDecimal(), now),
+            listOf(null, null, null),
          )
 
          val result = query(Query("SELECT * FROM foo"))
 
-         result shouldBe listOf(
-            mapOf("id" to 1, "bar" to "baz"),
-            mapOf("id" to 2, "bar" to null),
-         )
+         result.size shouldBe 2
+         result[0].get<Int>("id") shouldBe 1
+         result[0].get<String>("bar") shouldBe "baz"
+         result[0].get<BigDecimal>("number") shouldBe "123.01".toBigDecimal()
+         result[0].get<Instant>("timestamp") shouldBeEqual now
+         result[1].get<Int>("id") shouldBe 2
+         result[1].getOrNull<String>("bar") shouldBe null
       }
    }
 })

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/JdbcTransactionTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/JdbcTransactionTest.kt
@@ -4,6 +4,7 @@ import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.Rollback
 import io.github.kantis.mikrom.execute
+import io.github.kantis.mikrom.get
 import io.github.kantis.mikrom.jdbc.h2.prepareH2Database
 import io.github.kantis.mikrom.queryFor
 import io.kotest.core.spec.style.FunSpec
@@ -16,7 +17,7 @@ data class TestRecord(val id: Int, val name: String)
 class JdbcTransactionTest : FunSpec(
    {
       val mikrom = Mikrom {
-         registerRowMapper { row -> TestRecord(row["id"] as Int, row["name"] as String) }
+         registerRowMapper { row -> TestRecord(row.get("id"), row.get("name")) }
       }
 
       val dataSource = prepareH2Database(

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/JdbcTransactionTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/JdbcTransactionTest.kt
@@ -17,7 +17,7 @@ data class TestRecord(val id: Int, val name: String)
 class JdbcTransactionTest : FunSpec(
    {
       val mikrom = Mikrom {
-         registerRowMapper { row -> TestRecord(row.get("id"), row.get("name")) }
+         registerRowMapper { row, mikrom -> with(mikrom) { TestRecord(row.get("id"), row.get("name")) } }
       }
 
       val dataSource = prepareH2Database(
@@ -38,10 +38,10 @@ class JdbcTransactionTest : FunSpec(
       test("transaction commits data when returning TransactionResult.Commit") {
          // Insert data and commit
          dataSource.transaction {
-            mikrom.execute(
-               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-               listOf(1, "committed_name"),
-            )
+             mikrom.execute(
+                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+                 listOf(1, "committed_name"),
+             )
          }
 
          // Verify data persists after commit
@@ -55,17 +55,17 @@ class JdbcTransactionTest : FunSpec(
       test("transaction rolls back data when returning TransactionResult.Rollback") {
          // Insert initial data and commit
          dataSource.transaction {
-            mikrom.execute(
-               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-               listOf(1, "initial_name"),
-            )
+             mikrom.execute(
+                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+                 listOf(1, "initial_name"),
+             )
          }
 
          // Insert more data but rollback
          dataSource.transaction {
             mikrom.execute(
-               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-               listOf(2, "rolled_back_name"),
+                Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+                listOf(2, "rolled_back_name"),
             )
             Rollback
          }
@@ -80,18 +80,18 @@ class JdbcTransactionTest : FunSpec(
       test("transaction rolls back when exception is thrown") {
          // Insert initial data and commit
          dataSource.transaction {
-            mikrom.execute(
-               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-               listOf(1, "initial_name"),
-            )
+             mikrom.execute(
+                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+                 listOf(1, "initial_name"),
+             )
          }
 
          // Attempt transaction that throws exception
          try {
             dataSource.transaction {
                mikrom.execute(
-                  Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-                  listOf(2, "exception_name"),
+                   Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+                   listOf(2, "exception_name"),
                )
                throw RuntimeException("Simulated error")
             }
@@ -110,18 +110,18 @@ class JdbcTransactionTest : FunSpec(
       test("transaction can update existing data and commit") {
          // Insert initial data
          dataSource.transaction {
-            mikrom.execute(
-               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-               listOf(1, "original_name"),
-            )
+             mikrom.execute(
+                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+                 listOf(1, "original_name"),
+             )
          }
 
          // Update data and commit
          dataSource.transaction {
-            mikrom.execute(
-               Query("UPDATE test_records SET name = ? WHERE id = ?"),
-               listOf("updated_name", 1),
-            )
+             mikrom.execute(
+                 Query("UPDATE test_records SET name = ? WHERE id = ?"),
+                 listOf("updated_name", 1),
+             )
          }
 
          // Verify update was committed
@@ -136,17 +136,17 @@ class JdbcTransactionTest : FunSpec(
 
          // Insert initial data
          dataSource.transaction {
-            mikrom.execute(
-               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-               listOf(1, "original_name"),
-            )
+             mikrom.execute(
+                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+                 listOf(1, "original_name"),
+             )
          }
 
          // Update data but rollback
          dataSource.transaction {
             mikrom.execute(
-               Query("UPDATE test_records SET name = ? WHERE id = ?"),
-               listOf("updated_name", 1),
+                Query("UPDATE test_records SET name = ? WHERE id = ?"),
+                listOf("updated_name", 1),
             )
             Rollback
          }

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/JdbcTransactionTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/JdbcTransactionTest.kt
@@ -17,7 +17,7 @@ data class TestRecord(val id: Int, val name: String)
 class JdbcTransactionTest : FunSpec(
    {
       val mikrom = Mikrom {
-         registerRowMapper { row, mikrom -> with(mikrom) { TestRecord(row.get("id"), row.get("name")) } }
+         registerRowMapper { row -> TestRecord(row.get("id"), row.get("name")) }
       }
 
       val dataSource = prepareH2Database(
@@ -38,10 +38,10 @@ class JdbcTransactionTest : FunSpec(
       test("transaction commits data when returning TransactionResult.Commit") {
          // Insert data and commit
          dataSource.transaction {
-             mikrom.execute(
-                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-                 listOf(1, "committed_name"),
-             )
+            mikrom.execute(
+               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+               listOf(1, "committed_name"),
+            )
          }
 
          // Verify data persists after commit
@@ -55,17 +55,17 @@ class JdbcTransactionTest : FunSpec(
       test("transaction rolls back data when returning TransactionResult.Rollback") {
          // Insert initial data and commit
          dataSource.transaction {
-             mikrom.execute(
-                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-                 listOf(1, "initial_name"),
-             )
+            mikrom.execute(
+               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+               listOf(1, "initial_name"),
+            )
          }
 
          // Insert more data but rollback
          dataSource.transaction {
             mikrom.execute(
-                Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-                listOf(2, "rolled_back_name"),
+               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+               listOf(2, "rolled_back_name"),
             )
             Rollback
          }
@@ -80,18 +80,18 @@ class JdbcTransactionTest : FunSpec(
       test("transaction rolls back when exception is thrown") {
          // Insert initial data and commit
          dataSource.transaction {
-             mikrom.execute(
-                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-                 listOf(1, "initial_name"),
-             )
+            mikrom.execute(
+               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+               listOf(1, "initial_name"),
+            )
          }
 
          // Attempt transaction that throws exception
          try {
             dataSource.transaction {
                mikrom.execute(
-                   Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-                   listOf(2, "exception_name"),
+                  Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+                  listOf(2, "exception_name"),
                )
                throw RuntimeException("Simulated error")
             }
@@ -110,18 +110,18 @@ class JdbcTransactionTest : FunSpec(
       test("transaction can update existing data and commit") {
          // Insert initial data
          dataSource.transaction {
-             mikrom.execute(
-                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-                 listOf(1, "original_name"),
-             )
+            mikrom.execute(
+               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+               listOf(1, "original_name"),
+            )
          }
 
          // Update data and commit
          dataSource.transaction {
-             mikrom.execute(
-                 Query("UPDATE test_records SET name = ? WHERE id = ?"),
-                 listOf("updated_name", 1),
-             )
+            mikrom.execute(
+               Query("UPDATE test_records SET name = ? WHERE id = ?"),
+               listOf("updated_name", 1),
+            )
          }
 
          // Verify update was committed
@@ -136,17 +136,17 @@ class JdbcTransactionTest : FunSpec(
 
          // Insert initial data
          dataSource.transaction {
-             mikrom.execute(
-                 Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
-                 listOf(1, "original_name"),
-             )
+            mikrom.execute(
+               Query("INSERT INTO test_records (id, name) VALUES (?, ?)"),
+               listOf(1, "original_name"),
+            )
          }
 
          // Update data but rollback
          dataSource.transaction {
             mikrom.execute(
-                Query("UPDATE test_records SET name = ? WHERE id = ?"),
-                listOf("updated_name", 1),
+               Query("UPDATE test_records SET name = ? WHERE id = ?"),
+               listOf("updated_name", 1),
             )
             Rollback
          }

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcPostgresTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcPostgresTest.kt
@@ -22,14 +22,12 @@ class MikromJdbcPostgresTest : FunSpec(
       val dataSource = JdbcDataSource(postgres)
 
       val mikrom = Mikrom {
-         registerRowMapper { row, mikrom ->
-            with(mikrom) {
-               Book(
-                  row.get("author"),
-                  row.get("title"),
-                  row.get("number_of_pages"),
-               )
-            }
+         registerRowMapper { row ->
+            Book(
+               row.get("author"),
+               row.get("title"),
+               row.get("number_of_pages"),
+            )
          }
       }
 
@@ -56,8 +54,9 @@ class MikromJdbcPostgresTest : FunSpec(
       test("Reading data outside of transaction") {
          dataSource.transaction {
             mikrom.execute(
-                Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
-                listOf("George Orwell", "1984", 328),
+               Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
+               listOf("JRR Tolkien", "The Hobbit", 310),
+               listOf("George Orwell", "1984", 328),
             )
 
             val books = mikrom.queryFor<Book>(
@@ -82,10 +81,11 @@ class MikromJdbcPostgresTest : FunSpec(
 
       test("Should not allow SQL injection") {
          dataSource.transaction {
-             mikrom.execute(
-                 Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
-                 listOf("George Orwell", "1984", 328),
-             )
+            mikrom.execute(
+               Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
+               listOf("JRR Tolkien", "The Hobbit", 310),
+               listOf("George Orwell", "1984", 328),
+            )
          }
 
          dataSource.transaction {
@@ -103,8 +103,9 @@ class MikromJdbcPostgresTest : FunSpec(
       test("Should work with Postgres") {
          dataSource.transaction {
             mikrom.execute(
-                Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
-                listOf("George Orwell", "1984", 328),
+               Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
+               listOf("JRR Tolkien", "The Hobbit", 310),
+               listOf("George Orwell", "1984", 328),
             )
 
             mikrom.queryFor<Book>(Query("SELECT * FROM books")) shouldBe

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcPostgresTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcPostgresTest.kt
@@ -4,6 +4,7 @@ import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.Rollback
 import io.github.kantis.mikrom.execute
+import io.github.kantis.mikrom.get
 import io.github.kantis.mikrom.queryFor
 import io.kotest.core.extensions.install
 import io.kotest.core.spec.style.FunSpec
@@ -23,9 +24,9 @@ class MikromJdbcPostgresTest : FunSpec(
       val mikrom = Mikrom {
          registerRowMapper { row ->
             Book(
-               row["author"] as String,
-               row["title"] as String,
-               row["number_of_pages"] as Int,
+               row.get("author"),
+               row.get("title"),
+               row.get("number_of_pages"),
             )
          }
       }

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcPostgresTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcPostgresTest.kt
@@ -22,12 +22,14 @@ class MikromJdbcPostgresTest : FunSpec(
       val dataSource = JdbcDataSource(postgres)
 
       val mikrom = Mikrom {
-         registerRowMapper { row ->
-            Book(
-               row.get("author"),
-               row.get("title"),
-               row.get("number_of_pages"),
-            )
+         registerRowMapper { row, mikrom ->
+            with(mikrom) {
+               Book(
+                  row.get("author"),
+                  row.get("title"),
+                  row.get("number_of_pages"),
+               )
+            }
          }
       }
 
@@ -54,9 +56,8 @@ class MikromJdbcPostgresTest : FunSpec(
       test("Reading data outside of transaction") {
          dataSource.transaction {
             mikrom.execute(
-               Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
-               listOf("JRR Tolkien", "The Hobbit", 310),
-               listOf("George Orwell", "1984", 328),
+                Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
+                listOf("George Orwell", "1984", 328),
             )
 
             val books = mikrom.queryFor<Book>(
@@ -81,11 +82,10 @@ class MikromJdbcPostgresTest : FunSpec(
 
       test("Should not allow SQL injection") {
          dataSource.transaction {
-            mikrom.execute(
-               Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
-               listOf("JRR Tolkien", "The Hobbit", 310),
-               listOf("George Orwell", "1984", 328),
-            )
+             mikrom.execute(
+                 Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
+                 listOf("George Orwell", "1984", 328),
+             )
          }
 
          dataSource.transaction {
@@ -103,9 +103,8 @@ class MikromJdbcPostgresTest : FunSpec(
       test("Should work with Postgres") {
          dataSource.transaction {
             mikrom.execute(
-               Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
-               listOf("JRR Tolkien", "The Hobbit", 310),
-               listOf("George Orwell", "1984", 328),
+                Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
+                listOf("George Orwell", "1984", 328),
             )
 
             mikrom.queryFor<Book>(Query("SELECT * FROM books")) shouldBe

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcTest.kt
@@ -16,14 +16,12 @@ class MikromJdbcTest : FunSpec(
       test("integrate with H2 JDBC data source") {
          val mikrom =
             Mikrom {
-               registerRowMapper { row, mikrom ->
-                  with(mikrom) {
-                     Book(
-                        row.get("author"),
-                        row.get("title"),
-                        row.get("number_of_pages"),
-                     )
-                  }
+               registerRowMapper { row ->
+                  Book(
+                     row.get("author"),
+                     row.get("title"),
+                     row.get("number_of_pages"),
+                  )
                }
             }
 
@@ -40,6 +38,7 @@ class MikromJdbcTest : FunSpec(
          dataSource.transaction {
             mikrom.execute(
                Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
+               listOf("JRR Tolkien", "The Hobbit", 310),
                listOf("George Orwell", "1984", 328),
             )
 

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcTest.kt
@@ -3,6 +3,7 @@ package io.github.kantis.mikrom.jdbc
 import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.execute
+import io.github.kantis.mikrom.get
 import io.github.kantis.mikrom.jdbc.h2.prepareH2Database
 import io.github.kantis.mikrom.queryFor
 import io.kotest.core.spec.style.FunSpec
@@ -17,9 +18,9 @@ class MikromJdbcTest : FunSpec(
             Mikrom {
                registerRowMapper { row ->
                   Book(
-                     row["author"] as String,
-                     row["title"] as String,
-                     row["number_of_pages"] as Int,
+                     row.get("author"),
+                     row.get("title"),
+                     row.get("number_of_pages"),
                   )
                }
             }

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/MikromJdbcTest.kt
@@ -16,12 +16,14 @@ class MikromJdbcTest : FunSpec(
       test("integrate with H2 JDBC data source") {
          val mikrom =
             Mikrom {
-               registerRowMapper { row ->
-                  Book(
-                     row.get("author"),
-                     row.get("title"),
-                     row.get("number_of_pages"),
-                  )
+               registerRowMapper { row, mikrom ->
+                  with(mikrom) {
+                     Book(
+                        row.get("author"),
+                        row.get("title"),
+                        row.get("number_of_pages"),
+                     )
+                  }
                }
             }
 
@@ -38,7 +40,6 @@ class MikromJdbcTest : FunSpec(
          dataSource.transaction {
             mikrom.execute(
                Query("INSERT INTO books (author, title, number_of_pages) VALUES (?, ?, ?)"),
-               listOf("JRR Tolkien", "The Hobbit", 310),
                listOf("George Orwell", "1984", 328),
             )
 

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/QueryingForPrimitivesTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/QueryingForPrimitivesTest.kt
@@ -32,6 +32,7 @@ class QueryingForPrimitivesTest : FunSpec({
       dataSource.transaction {
          mikrom.execute(
             Query("INSERT INTO foo (bar) VALUES (?)"),
+            listOf("baz"),
             listOf("qux"),
          )
 
@@ -45,6 +46,7 @@ class QueryingForPrimitivesTest : FunSpec({
       dataSource.transaction {
          mikrom.execute(
             Query("INSERT INTO foo (bar) VALUES (?)"),
+            listOf("baz"),
             listOf("qux"),
          )
 

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/QueryingForPrimitivesTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/QueryingForPrimitivesTest.kt
@@ -32,7 +32,6 @@ class QueryingForPrimitivesTest : FunSpec({
       dataSource.transaction {
          mikrom.execute(
             Query("INSERT INTO foo (bar) VALUES (?)"),
-            listOf("baz"),
             listOf("qux"),
          )
 
@@ -46,7 +45,6 @@ class QueryingForPrimitivesTest : FunSpec({
       dataSource.transaction {
          mikrom.execute(
             Query("INSERT INTO foo (bar) VALUES (?)"),
-            listOf("baz"),
             listOf("qux"),
          )
 

--- a/mikrom/mikrom-r2dbc/src/jvmMain/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransaction.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmMain/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransaction.kt
@@ -2,6 +2,7 @@ package io.github.kantis.mikrom.r2dbc
 
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.Row
+import io.github.kantis.mikrom.buildRow
 import io.github.kantis.mikrom.suspend.SuspendingTransaction
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.Statement
@@ -59,8 +60,14 @@ public class R2dbcTransaction(private val connection: Connection, override val c
          .asFlow()
          .collect { result ->
             result.map { row, rowMetadata ->
-               rowMetadata.columnMetadatas.associate { metadata ->
-                  metadata.name to row.get(metadata.name)
+               buildRow {
+                  for (metadata in rowMetadata.columnMetadatas) {
+                     column(
+                        name = metadata.name,
+                        value = row.get(metadata.name),
+                        sqlTypeName = metadata.type?.name,
+                     )
+                  }
                }
             }.asFlow().collect(collector)
          }

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/MikromR2dbcTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/MikromR2dbcTest.kt
@@ -18,12 +18,14 @@ class MikromR2dbcTest : FunSpec(
    {
       test("integrate with R2DBC PostgreSQL data source") {
          val mikrom = Mikrom {
-            registerRowMapper { row ->
-               Book(
-                  row.get("author"),
-                  row.get("title"),
-                  row.get("number_of_pages"),
-               )
+            registerRowMapper { row, mikrom ->
+               with(mikrom) {
+                  Book(
+                     row.get("author"),
+                     row.get("title"),
+                     row.get("number_of_pages"),
+                  )
+               }
             }
          }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/MikromR2dbcTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/MikromR2dbcTest.kt
@@ -18,14 +18,12 @@ class MikromR2dbcTest : FunSpec(
    {
       test("integrate with R2DBC PostgreSQL data source") {
          val mikrom = Mikrom {
-            registerRowMapper { row, mikrom ->
-               with(mikrom) {
-                  Book(
-                     row.get("author"),
-                     row.get("title"),
-                     row.get("number_of_pages"),
-                  )
-               }
+            registerRowMapper { row ->
+               Book(
+                  row.get("author"),
+                  row.get("title"),
+                  row.get("number_of_pages"),
+               )
             }
          }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/MikromR2dbcTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/MikromR2dbcTest.kt
@@ -2,6 +2,7 @@ package io.github.kantis.mikrom.r2dbc
 
 import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
+import io.github.kantis.mikrom.get
 import io.github.kantis.mikrom.r2dbc.helpers.preparePostgresDatabase
 import io.github.kantis.mikrom.suspend.executeStreaming
 import io.github.kantis.mikrom.suspend.queryFor
@@ -19,9 +20,9 @@ class MikromR2dbcTest : FunSpec(
          val mikrom = Mikrom {
             registerRowMapper { row ->
                Book(
-                  row["author"] as String,
-                  row["title"] as String,
-                  row["number_of_pages"] as Int,
+                  row.get("author"),
+                  row.get("title"),
+                  row.get("number_of_pages"),
                )
             }
          }

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcDataTypesTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcDataTypesTest.kt
@@ -30,21 +30,19 @@ private data class DataTypeRecord(
 
 class R2dbcDataTypesTest : FunSpec({
    val mikrom = Mikrom {
-      registerRowMapper { row, mikrom ->
-         with(mikrom) {
-            DataTypeRecord(
-               id = row.get("id"),
-               stringField = row.getOrNull("string_field"),
-               intField = row.getOrNull("int_field"),
-               longField = row.getOrNull("long_field"),
-               booleanField = row.getOrNull("boolean_field"),
-               doubleField = row.getOrNull("double_field"),
-               decimalField = row.getOrNull("decimal_field"),
-               dateField = row.getOrNull("date_field"),
-               timestampField = row.getOrNull("timestamp_field"),
-               uuidField = row.getOrNull("uuid_field"),
-            )
-         }
+      registerRowMapper { row ->
+         DataTypeRecord(
+            id = row.get("id"),
+            stringField = row.getOrNull("string_field"),
+            intField = row.getOrNull("int_field"),
+            longField = row.getOrNull("long_field"),
+            booleanField = row.getOrNull("boolean_field"),
+            doubleField = row.getOrNull("double_field"),
+            decimalField = row.getOrNull("decimal_field"),
+            dateField = row.getOrNull("date_field"),
+            timestampField = row.getOrNull("timestamp_field"),
+            uuidField = row.getOrNull("uuid_field"),
+         )
       }
    }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcDataTypesTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcDataTypesTest.kt
@@ -30,19 +30,21 @@ private data class DataTypeRecord(
 
 class R2dbcDataTypesTest : FunSpec({
    val mikrom = Mikrom {
-      registerRowMapper { row ->
-         DataTypeRecord(
-            id = row.get("id"),
-            stringField = row.getOrNull("string_field"),
-            intField = row.getOrNull("int_field"),
-            longField = row.getOrNull("long_field"),
-            booleanField = row.getOrNull("boolean_field"),
-            doubleField = row.getOrNull("double_field"),
-            decimalField = row.getOrNull("decimal_field"),
-            dateField = row.getOrNull("date_field"),
-            timestampField = row.getOrNull("timestamp_field"),
-            uuidField = row.getOrNull("uuid_field"),
-         )
+      registerRowMapper { row, mikrom ->
+         with(mikrom) {
+            DataTypeRecord(
+               id = row.get("id"),
+               stringField = row.getOrNull("string_field"),
+               intField = row.getOrNull("int_field"),
+               longField = row.getOrNull("long_field"),
+               booleanField = row.getOrNull("boolean_field"),
+               doubleField = row.getOrNull("double_field"),
+               decimalField = row.getOrNull("decimal_field"),
+               dateField = row.getOrNull("date_field"),
+               timestampField = row.getOrNull("timestamp_field"),
+               uuidField = row.getOrNull("uuid_field"),
+            )
+         }
       }
    }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcDataTypesTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcDataTypesTest.kt
@@ -2,6 +2,8 @@ package io.github.kantis.mikrom.r2dbc
 
 import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
+import io.github.kantis.mikrom.get
+import io.github.kantis.mikrom.getOrNull
 import io.github.kantis.mikrom.r2dbc.helpers.preparePostgresDatabase
 import io.github.kantis.mikrom.suspend.execute
 import io.github.kantis.mikrom.suspend.queryFor
@@ -30,16 +32,16 @@ class R2dbcDataTypesTest : FunSpec({
    val mikrom = Mikrom {
       registerRowMapper { row ->
          DataTypeRecord(
-            id = row["id"] as Int,
-            stringField = row["string_field"] as String?,
-            intField = row["int_field"] as Int?,
-            longField = row["long_field"] as Long?,
-            booleanField = row["boolean_field"] as Boolean?,
-            doubleField = row["double_field"] as Double?,
-            decimalField = row["decimal_field"] as BigDecimal?,
-            dateField = row["date_field"] as LocalDate?,
-            timestampField = row["timestamp_field"] as LocalDateTime?,
-            uuidField = row["uuid_field"] as UUID?,
+            id = row.get("id"),
+            stringField = row.getOrNull("string_field"),
+            intField = row.getOrNull("int_field"),
+            longField = row.getOrNull("long_field"),
+            booleanField = row.getOrNull("boolean_field"),
+            doubleField = row.getOrNull("double_field"),
+            decimalField = row.getOrNull("decimal_field"),
+            dateField = row.getOrNull("date_field"),
+            timestampField = row.getOrNull("timestamp_field"),
+            uuidField = row.getOrNull("uuid_field"),
          )
       }
    }

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransactionTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransactionTest.kt
@@ -3,6 +3,7 @@ package io.github.kantis.mikrom.r2dbc
 import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.Rollback
+import io.github.kantis.mikrom.get
 import io.github.kantis.mikrom.r2dbc.helpers.preparePostgresDatabase
 import io.github.kantis.mikrom.suspend.execute
 import io.github.kantis.mikrom.suspend.queryFor
@@ -18,8 +19,8 @@ class R2dbcTransactionTest : FunSpec(
       val mikrom = Mikrom {
          registerRowMapper { row ->
             TestRecord(
-               row["id"] as Int,
-               row["name"] as String,
+               row.get("id"),
+               row.get("name"),
             )
          }
       }

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransactionTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransactionTest.kt
@@ -17,11 +17,13 @@ private data class TestRecord(val id: Int, val name: String)
 class R2dbcTransactionTest : FunSpec(
    {
       val mikrom = Mikrom {
-         registerRowMapper { row ->
-            TestRecord(
-               row.get("id"),
-               row.get("name"),
-            )
+         registerRowMapper { row, mikrom ->
+            with(mikrom) {
+               TestRecord(
+                  row.get("id"),
+                  row.get("name"),
+               )
+            }
          }
       }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransactionTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransactionTest.kt
@@ -17,13 +17,11 @@ private data class TestRecord(val id: Int, val name: String)
 class R2dbcTransactionTest : FunSpec(
    {
       val mikrom = Mikrom {
-         registerRowMapper { row, mikrom ->
-            with(mikrom) {
-               TestRecord(
-                  row.get("id"),
-                  row.get("name"),
-               )
-            }
+         registerRowMapper { row ->
+            TestRecord(
+               row.get("id"),
+               row.get("name"),
+            )
          }
       }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcDataTypesTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcDataTypesTest.kt
@@ -33,21 +33,19 @@ private data class DataTypeRecord(
 
 class R2dbcDataTypesTest : FunSpec({
    val mikrom = Mikrom {
-      registerRowMapper { row, mikrom ->
-         with(mikrom) {
-            DataTypeRecord(
-               id = row.get("id"),
-               stringField = row.getOrNull("string_field"),
-               intField = row.getOrNull("int_field"),
-               longField = row.getOrNull("long_field"),
-               booleanField = row.getOrNull("boolean_field"),
-               doubleField = row.getOrNull("double_field"),
-               decimalField = row.getOrNull("decimal_field"),
-               dateField = row.getOrNull("date_field"),
-               timestampField = row.getOrNull("timestamp_field"),
-               uuidField = row.getOrNull("uuid_field"),
-            )
-         }
+      registerRowMapper { row ->
+         DataTypeRecord(
+            id = row.get("id"),
+            stringField = row.getOrNull("string_field"),
+            intField = row.getOrNull("int_field"),
+            longField = row.getOrNull("long_field"),
+            booleanField = row.getOrNull("boolean_field"),
+            doubleField = row.getOrNull("double_field"),
+            decimalField = row.getOrNull("decimal_field"),
+            dateField = row.getOrNull("date_field"),
+            timestampField = row.getOrNull("timestamp_field"),
+            uuidField = row.getOrNull("uuid_field"),
+         )
       }
    }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcDataTypesTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcDataTypesTest.kt
@@ -33,19 +33,21 @@ private data class DataTypeRecord(
 
 class R2dbcDataTypesTest : FunSpec({
    val mikrom = Mikrom {
-      registerRowMapper { row ->
-         DataTypeRecord(
-            id = row.get("id"),
-            stringField = row.getOrNull("string_field"),
-            intField = row.getOrNull("int_field"),
-            longField = row.getOrNull("long_field"),
-            booleanField = row.getOrNull("boolean_field"),
-            doubleField = row.getOrNull("double_field"),
-            decimalField = row.getOrNull("decimal_field"),
-            dateField = row.getOrNull("date_field"),
-            timestampField = row.getOrNull("timestamp_field"),
-            uuidField = row.getOrNull("uuid_field"),
-         )
+      registerRowMapper { row, mikrom ->
+         with(mikrom) {
+            DataTypeRecord(
+               id = row.get("id"),
+               stringField = row.getOrNull("string_field"),
+               intField = row.getOrNull("int_field"),
+               longField = row.getOrNull("long_field"),
+               booleanField = row.getOrNull("boolean_field"),
+               doubleField = row.getOrNull("double_field"),
+               decimalField = row.getOrNull("decimal_field"),
+               dateField = row.getOrNull("date_field"),
+               timestampField = row.getOrNull("timestamp_field"),
+               uuidField = row.getOrNull("uuid_field"),
+            )
+         }
       }
    }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcDataTypesTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcDataTypesTest.kt
@@ -2,6 +2,8 @@ package io.github.kantis.mikrom.r2dbc.stream
 
 import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
+import io.github.kantis.mikrom.get
+import io.github.kantis.mikrom.getOrNull
 import io.github.kantis.mikrom.r2dbc.PooledR2dbcDataSource
 import io.github.kantis.mikrom.r2dbc.helpers.preparePostgresDatabase
 import io.github.kantis.mikrom.suspend.execute
@@ -33,16 +35,16 @@ class R2dbcDataTypesTest : FunSpec({
    val mikrom = Mikrom {
       registerRowMapper { row ->
          DataTypeRecord(
-            id = row["id"] as Int,
-            stringField = row["string_field"] as String?,
-            intField = row["int_field"] as Int?,
-            longField = row["long_field"] as Long?,
-            booleanField = row["boolean_field"] as Boolean?,
-            doubleField = row["double_field"] as Double?,
-            decimalField = row["decimal_field"] as BigDecimal?,
-            dateField = row["date_field"] as LocalDate?,
-            timestampField = row["timestamp_field"] as LocalDateTime?,
-            uuidField = row["uuid_field"] as UUID?,
+            id = row.get("id"),
+            stringField = row.getOrNull("string_field"),
+            intField = row.getOrNull("int_field"),
+            longField = row.getOrNull("long_field"),
+            booleanField = row.getOrNull("boolean_field"),
+            doubleField = row.getOrNull("double_field"),
+            decimalField = row.getOrNull("decimal_field"),
+            dateField = row.getOrNull("date_field"),
+            timestampField = row.getOrNull("timestamp_field"),
+            uuidField = row.getOrNull("uuid_field"),
          )
       }
    }

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcTransactionTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcTransactionTest.kt
@@ -3,6 +3,7 @@ package io.github.kantis.mikrom.r2dbc.stream
 import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.Rollback
+import io.github.kantis.mikrom.get
 import io.github.kantis.mikrom.r2dbc.PooledR2dbcDataSource
 import io.github.kantis.mikrom.r2dbc.helpers.preparePostgresDatabase
 import io.github.kantis.mikrom.suspend.execute
@@ -21,8 +22,8 @@ class R2dbcTransactionTest : FunSpec(
       val mikrom = Mikrom {
          registerRowMapper { row ->
             TestRecord(
-               row["id"] as Int,
-               row["name"] as String,
+               row.get("id"),
+               row.get("name"),
             )
          }
       }

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcTransactionTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcTransactionTest.kt
@@ -20,13 +20,11 @@ private data class TestRecord(val id: Int, val name: String)
 class R2dbcTransactionTest : FunSpec(
    {
       val mikrom = Mikrom {
-         registerRowMapper { row, mikrom ->
-            with(mikrom) {
-               TestRecord(
-                  row.get("id"),
-                  row.get("name"),
-               )
-            }
+         registerRowMapper { row ->
+            TestRecord(
+               row.get("id"),
+               row.get("name"),
+            )
          }
       }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcTransactionTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/R2dbcTransactionTest.kt
@@ -20,11 +20,13 @@ private data class TestRecord(val id: Int, val name: String)
 class R2dbcTransactionTest : FunSpec(
    {
       val mikrom = Mikrom {
-         registerRowMapper { row ->
-            TestRecord(
-               row.get("id"),
-               row.get("name"),
-            )
+         registerRowMapper { row, mikrom ->
+            with(mikrom) {
+               TestRecord(
+                  row.get("id"),
+                  row.get("name"),
+               )
+            }
          }
       }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/StreamingMikromR2dbcTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/StreamingMikromR2dbcTest.kt
@@ -18,14 +18,12 @@ class StreamingMikromR2dbcTest : FunSpec(
    {
       test("integrate with R2DBC PostgreSQL data source") {
          val mikrom = Mikrom {
-            registerRowMapper { row, mikrom ->
-               with(mikrom) {
-                  Book(
-                     row.get("author"),
-                     row.get("title"),
-                     row.get("number_of_pages"),
-                  )
-               }
+            registerRowMapper { row ->
+               Book(
+                  row.get("author"),
+                  row.get("title"),
+                  row.get("number_of_pages"),
+               )
             }
          }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/StreamingMikromR2dbcTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/StreamingMikromR2dbcTest.kt
@@ -18,12 +18,14 @@ class StreamingMikromR2dbcTest : FunSpec(
    {
       test("integrate with R2DBC PostgreSQL data source") {
          val mikrom = Mikrom {
-            registerRowMapper { row ->
-               Book(
-                  row.get("author"),
-                  row.get("title"),
-                  row.get("number_of_pages"),
-               )
+            registerRowMapper { row, mikrom ->
+               with(mikrom) {
+                  Book(
+                     row.get("author"),
+                     row.get("title"),
+                     row.get("number_of_pages"),
+                  )
+               }
             }
          }
 

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/StreamingMikromR2dbcTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/stream/StreamingMikromR2dbcTest.kt
@@ -2,6 +2,7 @@ package io.github.kantis.mikrom.r2dbc.stream
 
 import io.github.kantis.mikrom.Mikrom
 import io.github.kantis.mikrom.Query
+import io.github.kantis.mikrom.get
 import io.github.kantis.mikrom.r2dbc.helpers.preparePostgresDatabase
 import io.github.kantis.mikrom.suspend.executeStreaming
 import io.github.kantis.mikrom.suspend.queryFor
@@ -19,9 +20,9 @@ class StreamingMikromR2dbcTest : FunSpec(
          val mikrom = Mikrom {
             registerRowMapper { row ->
                Book(
-                  row["author"] as String,
-                  row["title"] as String,
-                  row["number_of_pages"] as Int,
+                  row.get("author"),
+                  row.get("title"),
+                  row.get("number_of_pages"),
                )
             }
          }


### PR DESCRIPTION
## Summary
- Generate typed `Row.get`/`getOrNull` calls with `KClass` in the compiler plugin IR visitor
- Refactor type coercion to user-configurable `TypeConversions` and migrate to context parameters
- Add ergonomic `registerRowMapper` overload accepting `context(Mikrom) (Row) -> T`, restoring the concise `{ row -> ... }` lambda syntax
- Fix missing test data insertions in JDBC tests

## Test plan
- [x] Compiler plugin tests pass (`./gradlew :mikrom-compiler-plugin:test`)
- [x] Core tests pass (`./gradlew :mikrom:mikrom-core:jvmTest`)
- [x] JDBC tests pass (`./gradlew :mikrom:mikrom-jdbc:jvmTest`)
- [x] Full build passes (`./gradlew build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)