### PR TITLE
Configurable compiler plugin version

### DIFF
--- a/mikrom-gradle-plugin/api/mikrom-gradle-plugin.api
+++ b/mikrom-gradle-plugin/api/mikrom-gradle-plugin.api
@@ -1,5 +1,6 @@
 public class io/github/kantis/mikrom/gradle/MikromGradleExtension {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getCompilerPluginVersion ()Lorg/gradle/api/provider/Property;
 }
 
 public final class io/github/kantis/mikrom/gradle/MikromGradlePlugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {

--- a/mikrom-gradle-plugin/build.gradle.kts
+++ b/mikrom-gradle-plugin/build.gradle.kts
@@ -11,6 +11,22 @@ dependencies {
    implementation(kotlin("gradle-plugin-api"))
 }
 
+val generateVersionProperties by tasks.registering {
+   val outputDir = layout.buildDirectory.dir("generated/mikrom-resources")
+   val pluginVersion = project.version.toString()
+   inputs.property("version", pluginVersion)
+   outputs.dir(outputDir)
+   doLast {
+      val propsFile = outputDir.get().file("mikrom-gradle-plugin.properties").asFile
+      propsFile.parentFile.mkdirs()
+      propsFile.writeText("version=$pluginVersion\n")
+   }
+}
+
+sourceSets.main {
+   resources.srcDir(generateVersionProperties.map { it.outputs.files.singleFile })
+}
+
 gradlePlugin {
    website.set("https://github.com/kantis/mikrom")
    vcsUrl.set("https://github.com/kantis/mikrom.git")

--- a/mikrom-gradle-plugin/src/main/kotlin/io/github/kantis/mikrom/gradle/MikromGradleExtension.kt
+++ b/mikrom-gradle-plugin/src/main/kotlin/io/github/kantis/mikrom/gradle/MikromGradleExtension.kt
@@ -1,9 +1,20 @@
 package io.github.kantis.mikrom.gradle
 
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
 
 public open class MikromGradleExtension(objects: ObjectFactory) {
-   // Nothing yet..
-//   val stringProperty: Property<String> = objects.property(String::class.java)
-//   val fileProperty: RegularFileProperty = objects.fileProperty()
+   public val compilerPluginVersion: Property<String> =
+      objects.property(String::class.java).convention(readBuiltInVersion())
+}
+
+private fun readBuiltInVersion(): String {
+   val props = java.util.Properties()
+   val stream =
+      MikromGradleExtension::class.java.classLoader
+         .getResourceAsStream("mikrom-gradle-plugin.properties")
+         ?: error("Could not find mikrom-gradle-plugin.properties on classpath")
+   stream.use { props.load(it) }
+   return props.getProperty("version")
+      ?: error("mikrom-gradle-plugin.properties does not contain a 'version' property")
 }

--- a/mikrom-gradle-plugin/src/main/kotlin/io/github/kantis/mikrom/gradle/MikromGradlePlugin.kt
+++ b/mikrom-gradle-plugin/src/main/kotlin/io/github/kantis/mikrom/gradle/MikromGradlePlugin.kt
@@ -8,9 +8,11 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
 public class MikromGradlePlugin : KotlinCompilerPluginSupportPlugin {
+   private lateinit var extension: MikromGradleExtension
+
    override fun apply(target: Project): Unit =
       with(target) {
-         extensions.create("template", MikromGradleExtension::class.java)
+         extension = extensions.create("mikrom", MikromGradleExtension::class.java)
       }
 
    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
@@ -21,25 +23,13 @@ public class MikromGradlePlugin : KotlinCompilerPluginSupportPlugin {
       SubpluginArtifact(
          groupId = "io.github.kantis",
          artifactId = "mikrom-compiler-plugin",
-         version = "0.1.0-SNAPSHOT",
+         version = extension.compilerPluginVersion.get(),
       )
 
-//   override fun getPluginArtifactForNative(): SubpluginArtifact =
-//      SubpluginArtifact(
-//         groupId = "foo",
-//         artifactId = "bar-native",
-//         version = "1.1.0",
-//      )
-//
    override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
       val project = kotlinCompilation.target.project
-      val extension = project.extensions.getByType(MikromGradleExtension::class.java)
       return project.provider {
-         listOf(
-            // Nothing yet..
-//            SubpluginOption(key = "string", value = extension.stringProperty.get()),
-//            SubpluginOption(key = "file", value = extension.fileProperty.get().asFile.path),
-         )
+         listOf()
       }
    }
 }


### PR DESCRIPTION
## Summary
- The Gradle plugin now defaults to applying the compiler plugin at the same version as itself, instead of a hardcoded version
- The version is configurable via the mikrom extension compilerPluginVersion property, allowing users to override it
- Renames the extension from template to mikrom

## Test plan
- [ ] Verify gradle plugin build passes
- [ ] Verify the example project still compiles with the plugin applied
- [ ] Test overriding compilerPluginVersion in a consumer build script