### PR TITLE
Fix compiler plugin publishing

### DIFF
--- a/build-logic/src/main/kotlin/mikrom/conventions/publishing/maven-publish.gradle.kts
+++ b/build-logic/src/main/kotlin/mikrom/conventions/publishing/maven-publish.gradle.kts
@@ -16,6 +16,17 @@ val javadocJarStub by tasks.registering(Jar::class) {
    archiveClassifier.set("javadoc")
 }
 
+// kotlin("jvm") doesn't create a MavenPublication automatically, unlike kotlin("multiplatform")
+plugins.withId("org.jetbrains.kotlin.jvm") {
+   publishing {
+      publications {
+         create<MavenPublication>("Jvm") {
+            from(components["java"])
+         }
+      }
+   }
+}
+
 publishing {
    repositories {
       // Publish to a project-local Maven directory, for verification. To test, run:
@@ -26,35 +37,32 @@ publishing {
       }
    }
 
-   publications.withType<MavenPublication>().forEach {
-      it.apply {
+   publications.withType<MavenPublication>().configureEach {
+      artifact(javadocJarStub)
 
-         artifact(javadocJarStub)
+      pom {
+         name.set("mikrom")
+         description.set("KotlinX Serialization standard serializers")
+         url.set("https://github.com/Kantis/mikrom")
 
-         pom {
-            name.set("mikrom")
-            description.set("KotlinX Serialization standard serializers")
+         scm {
+            connection.set("scm:git:https://github.com/Kantis/mikrom/")
+            developerConnection.set("scm:git:https://github.com/Kantis/")
             url.set("https://github.com/Kantis/mikrom")
+         }
 
-            scm {
-               connection.set("scm:git:https://github.com/Kantis/mikrom/")
-               developerConnection.set("scm:git:https://github.com/Kantis/")
-               url.set("https://github.com/Kantis/mikrom")
+         licenses {
+            license {
+               name.set("Apache-2.0")
+               url.set("https://opensource.org/licenses/Apache-2.0")
             }
+         }
 
-            licenses {
-               license {
-                  name.set("Apache-2.0")
-                  url.set("https://opensource.org/licenses/Apache-2.0")
-               }
-            }
-
-            developers {
-               developer {
-                  id.set("Kantis")
-                  name.set("Emil Kantis")
-                  email.set("emil.kantis@protonmail.com")
-               }
+         developers {
+            developer {
+               id.set("Kantis")
+               name.set("Emil Kantis")
+               email.set("emil.kantis@protonmail.com")
             }
          }
       }

--- a/mikrom-compiler-plugin/build.gradle.kts
+++ b/mikrom-compiler-plugin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "io.github.kantis"
-version = "0.1.0-SNAPSHOT"
+version = findProperty("version") ?: "0.1.0-SNAPSHOT"
 
 kotlin {
    compilerOptions {


### PR DESCRIPTION
## Summary
- The compiler plugin was not being published because `kotlin("jvm")` doesn't automatically create `MavenPublication`s like `kotlin("multiplatform")` does
- The maven-publish convention now creates a `Jvm` publication for `kotlin("jvm")` projects, and uses `configureEach` instead of `forEach` so lazily-added publications get configured
- The compiler plugin version is now configurable via `-Pversion` instead of being hardcoded

## Test plan
- [ ] Run `./gradlew :mikrom-compiler-plugin:publishToMavenLocal -Pversion=0.2.1-LOCAL` and verify artifact appears in `~/.m2/repository/io/github/kantis/mikrom-compiler-plugin/0.2.1-LOCAL/`
- [ ] Run `./gradlew publishToMavenLocal` and verify all modules still publish correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)