### PR TITLE
Add @Column annotation for custom column name mapping

### DIFF
--- a/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/ir/MikromIrVisitor.kt
+++ b/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/ir/MikromIrVisitor.kt
@@ -58,6 +58,8 @@ internal class MikromIrVisitor(
       private val ROW_CLASS_ID = ClassId(FqName("io.github.kantis.mikrom"), Name.identifier("Row"))
       private val ROW_MAPPER_NESTED_NAME = Name.identifier("\$RowMapper")
 
+      private val COLUMN_CLASS_ID = ClassId(FqName("io.github.kantis.mikrom.generator"), Name.identifier("Column"))
+
       private val ILLEGAL_STATE_EXCEPTION_FQ_NAME =
          FqName("kotlin.IllegalStateException")
 
@@ -211,7 +213,7 @@ internal class MikromIrVisitor(
             value = irBlock {
                val rowRef = irGet(row)
                val mikromRef = irGet(mikrom)
-               val keyLiteral = irString(valueParameter.name.asString())
+               val keyLiteral = irString(columnName(valueParameter))
 
                val classRef = IrClassReferenceImpl(
                   startOffset,
@@ -233,5 +235,15 @@ internal class MikromIrVisitor(
       }
 
       return variables
+   }
+
+   private fun columnName(valueParameter: IrValueParameter): String {
+      val columnAnnotation = valueParameter.annotations.firstOrNull {
+         it.type.classifierOrNull == pluginContext.referenceClass(COLUMN_CLASS_ID)
+      } ?: return valueParameter.name.asString()
+
+      val nameArg = columnAnnotation.arguments[0]
+      return (nameArg as? org.jetbrains.kotlin.ir.expressions.IrConst)?.value as? String
+         ?: valueParameter.name.asString()
    }
 }

--- a/mikrom-compiler-plugin/test-gen/io/github/kantis/mikrom/plugin/BoxTestGenerated.java
+++ b/mikrom-compiler-plugin/test-gen/io/github/kantis/mikrom/plugin/BoxTestGenerated.java
@@ -21,6 +21,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
   }
 
   @Test
+  @TestMetadata("ColumnAnnotation.kt")
+  public void testColumnAnnotation() {
+    runTest("testData/box/ColumnAnnotation.kt");
+  }
+
+  @Test
   @TestMetadata("NullableValueClass.kt")
   public void testNullableValueClass() {
     runTest("testData/box/NullableValueClass.kt");

--- a/mikrom-compiler-plugin/testData/box/ColumnAnnotation.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/ColumnAnnotation.fir.ir.txt
@@ -1,0 +1,312 @@
+FILE fqName:<root> fileName:/ColumnAnnotation.kt
+  CLASS CLASS name:DbUser modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
+    annotations:
+      RowMapped
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.DbUser
+    PROPERTY name:name visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'name: kotlin.String declared in <root>.DbUser.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+        correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String declared in <root>.DbUser'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.<get-name>' type=<root>.DbUser origin=null
+    PROPERTY name:email visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:email type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'email: kotlin.String declared in <root>.DbUser.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-email> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+        correspondingProperty: PROPERTY name:email visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-email> (): kotlin.String declared in <root>.DbUser'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.<get-email>' type=<root>.DbUser origin=null
+    PROPERTY name:age visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'age: kotlin.Int declared in <root>.DbUser.<init>' type=kotlin.Int origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-age> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+        correspondingProperty: PROPERTY name:age visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-age> (): kotlin.Int declared in <root>.DbUser'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.<get-age>' type=<root>.DbUser origin=null
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.DbUser.Companion
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] visibility:private returnType:<root>.DbUser.Companion [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperAccessorKey] name:rowMapper visibility:public modality:FINAL returnType:io.github.kantis.mikrom.RowMapper<<root>.DbUser>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser.Companion
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun rowMapper (): io.github.kantis.mikrom.RowMapper<<root>.DbUser> declared in <root>.DbUser.Companion'
+            GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.DbUser>]' type=<root>.DbUser.$RowMapper
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.DbUser>]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.DbUser.$RowMapper
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] visibility:private returnType:<root>.DbUser.$RowMapper [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.DbUser>]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in io.github.kantis.mikrom.RowMapper
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in io.github.kantis.mikrom.RowMapper
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in io.github.kantis.mikrom.RowMapper
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] name:mapRow visibility:public modality:FINAL returnType:<root>.DbUser
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser.$RowMapper
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:row index:1 type:io.github.kantis.mikrom.Row
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:mikrom index:2 type:io.github.kantis.mikrom.Mikrom
+        overridden:
+          public abstract fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper
+        BLOCK_BODY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.String
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.DbUser.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.DbUser.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                ARG column: CONST String type=kotlin.String value="user_name"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+          VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.String
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.DbUser.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.DbUser.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                ARG column: CONST String type=kotlin.String value="email_address"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+          VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.Int
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.DbUser.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.DbUser.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                ARG column: CONST String type=kotlin.String value="age"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.Int>
+          RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.DbUser declared in <root>.DbUser.$RowMapper'
+            CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, email: kotlin.String, age: kotlin.Int) declared in <root>.DbUser' type=<root>.DbUser origin=null
+              ARG name: GET_VAR 'val tmp_0: T of io.github.kantis.mikrom.Row.get declared in <root>.DbUser.$RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
+              ARG email: GET_VAR 'val tmp_1: T of io.github.kantis.mikrom.Row.get declared in <root>.DbUser.$RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
+              ARG age: GET_VAR 'val tmp_2: T of io.github.kantis.mikrom.Row.get declared in <root>.DbUser.$RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.DbUser [primary]
+      VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
+        annotations:
+          Column(name = "user_name")
+      VALUE_PARAMETER kind:Regular name:email index:1 type:kotlin.String
+        annotations:
+          Column(name = "email_address")
+      VALUE_PARAMETER kind:Regular name:age index:2 type:kotlin.Int
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:DbUser modality:FINAL visibility:public [data] superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.DbUser'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.component1' type=<root>.DbUser origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:component2 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.String declared in <root>.DbUser'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.component2' type=<root>.DbUser origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:component3 visibility:public modality:FINAL returnType:kotlin.Int [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component3 (): kotlin.Int declared in <root>.DbUser'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.component3' type=<root>.DbUser origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL returnType:<root>.DbUser
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+        annotations:
+          Column(name = "user_name")
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.copy' type=<root>.DbUser origin=null
+      VALUE_PARAMETER kind:Regular name:email index:2 type:kotlin.String
+        annotations:
+          Column(name = "email_address")
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.copy' type=<root>.DbUser origin=null
+      VALUE_PARAMETER kind:Regular name:age index:3 type:kotlin.Int
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.copy' type=<root>.DbUser origin=null
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun copy (name: kotlin.String, email: kotlin.String, age: kotlin.Int): <root>.DbUser declared in <root>.DbUser'
+          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, email: kotlin.String, age: kotlin.Int) declared in <root>.DbUser' type=<root>.DbUser origin=null
+            ARG name: GET_VAR 'name: kotlin.String declared in <root>.DbUser.copy' type=kotlin.String origin=null
+            ARG email: GET_VAR 'email: kotlin.String declared in <root>.DbUser.copy' type=kotlin.String origin=null
+            ARG age: GET_VAR 'age: kotlin.Int declared in <root>.DbUser.copy' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+              ARG arg0: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.equals' type=<root>.DbUser origin=null
+              ARG arg1: GET_VAR 'other: kotlin.Any? declared in <root>.DbUser.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.DbUser'
+              CONST Boolean type=kotlin.Boolean value=true
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.DbUser
+              GET_VAR 'other: kotlin.Any? declared in <root>.DbUser.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.DbUser'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:<root>.DbUser [val]
+          TYPE_OP type=<root>.DbUser origin=IMPLICIT_CAST typeOperand=<root>.DbUser
+            GET_VAR 'other: kotlin.Any? declared in <root>.DbUser.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.equals' type=<root>.DbUser origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_3: <root>.DbUser declared in <root>.DbUser.equals' type=<root>.DbUser origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.DbUser'
+              CONST Boolean type=kotlin.Boolean value=false
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.equals' type=<root>.DbUser origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_3: <root>.DbUser declared in <root>.DbUser.equals' type=<root>.DbUser origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.DbUser'
+              CONST Boolean type=kotlin.Boolean value=false
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                  receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.equals' type=<root>.DbUser origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                  receiver: GET_VAR 'val tmp_3: <root>.DbUser declared in <root>.DbUser.equals' type=<root>.DbUser origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.DbUser'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.DbUser'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      BLOCK_BODY
+        VAR name:result type:kotlin.Int [var]
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.hashCode' type=<root>.DbUser origin=null
+        SET_VAR 'var result: kotlin.Int declared in <root>.DbUser.hashCode' type=kotlin.Unit origin=EQ
+          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'var result: kotlin.Int declared in <root>.DbUser.hashCode' type=kotlin.Int origin=null
+              ARG other: CONST Int type=kotlin.Int value=31
+            ARG other: CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+              ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.hashCode' type=<root>.DbUser origin=null
+        SET_VAR 'var result: kotlin.Int declared in <root>.DbUser.hashCode' type=kotlin.Unit origin=EQ
+          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'var result: kotlin.Int declared in <root>.DbUser.hashCode' type=kotlin.Int origin=null
+              ARG other: CONST Int type=kotlin.Int value=31
+            ARG other: CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.hashCode' type=<root>.DbUser origin=null
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.DbUser'
+          GET_VAR 'var result: kotlin.Int declared in <root>.DbUser.hashCode' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.DbUser
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.DbUser'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="DbUser("
+            CONST String type=kotlin.String value="name="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.toString' type=<root>.DbUser origin=null
+            CONST String type=kotlin.String value=", "
+            CONST String type=kotlin.String value="email="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.toString' type=<root>.DbUser origin=null
+            CONST String type=kotlin.String value=", "
+            CONST String type=kotlin.String value="age="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.DbUser declared in <root>.DbUser.toString' type=<root>.DbUser origin=null
+            CONST String type=kotlin.String value=")"
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+          ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
+            TYPE_ARG K: kotlin.reflect.KClass<*>
+            TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>
+          ARG conversions: CALL 'public final fun <get-EMPTY> (): io.github.kantis.mikrom.TypeConversions declared in io.github.kantis.mikrom.TypeConversions.Companion' type=io.github.kantis.mikrom.TypeConversions origin=GET_PROPERTY
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.TypeConversions.Companion
+      VAR name:user type:<root>.DbUser [val]
+        CALL 'public abstract fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper' type=<root>.DbUser origin=null
+          ARG <this>: CALL 'public final fun rowMapper (): io.github.kantis.mikrom.RowMapper<<root>.DbUser> declared in <root>.DbUser.Companion' type=io.github.kantis.mikrom.RowMapper<<root>.DbUser> origin=null
+            ARG <this>: GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=<root>.DbUser.Companion
+          ARG row: CALL 'public final fun of (vararg pairs: kotlin.Pair<kotlin.String, kotlin.Any?>): io.github.kantis.mikrom.Row declared in io.github.kantis.mikrom.Row.Companion' type=io.github.kantis.mikrom.Row origin=null
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.Row.Companion
+            ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlin.Any?>> varargElementType=kotlin.Pair<kotlin.String, kotlin.Any?>
+              CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlin.String> origin=null
+                TYPE_ARG A: kotlin.String
+                TYPE_ARG B: kotlin.String
+                ARG <this>: CONST String type=kotlin.String value="user_name"
+                ARG that: CONST String type=kotlin.String value="Alice"
+              CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlin.String> origin=null
+                TYPE_ARG A: kotlin.String
+                TYPE_ARG B: kotlin.String
+                ARG <this>: CONST String type=kotlin.String value="email_address"
+                ARG that: CONST String type=kotlin.String value="alice@example.com"
+              CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlin.Int> origin=null
+                TYPE_ARG A: kotlin.String
+                TYPE_ARG B: kotlin.Int
+                ARG <this>: CONST String type=kotlin.String value="age"
+                ARG that: CONST Int type=kotlin.Int value=30
+          ARG mikrom: GET_VAR 'val mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.box' type=io.github.kantis.mikrom.Mikrom origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: <root>.DbUser
+        ARG expected: GET_VAR 'val user: <root>.DbUser declared in <root>.box' type=<root>.DbUser origin=null
+        ARG actual: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, email: kotlin.String, age: kotlin.Int) declared in <root>.DbUser' type=<root>.DbUser origin=null
+          ARG name: CONST String type=kotlin.String value="Alice"
+          ARG email: CONST String type=kotlin.String value="alice@example.com"
+          ARG age: CONST Int type=kotlin.Int value=30
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/mikrom-compiler-plugin/testData/box/ColumnAnnotation.fir.txt
+++ b/mikrom-compiler-plugin/testData/box/ColumnAnnotation.fir.txt
@@ -1,0 +1,44 @@
+FILE: ColumnAnnotation.kt
+    public final fun box(): R|kotlin/String| {
+        lval mikrom: R|io/github/kantis/mikrom/Mikrom| = R|io/github/kantis/mikrom/Mikrom.Mikrom|(R|kotlin/collections/mutableMapOf|<R|kotlin/reflect/KClass<*>|, R|io/github/kantis/mikrom/RowMapper<*>|>(), Q|io/github/kantis/mikrom/TypeConversions|.R|io/github/kantis/mikrom/TypeConversions.Companion.EMPTY|)
+        lval user: R|DbUser| = Q|DbUser|.R|/DbUser.Companion.rowMapper|().R|SubstitutionOverride<io/github/kantis/mikrom/RowMapper.mapRow: R|DbUser|>|(Q|io/github/kantis/mikrom/Row|.R|io/github/kantis/mikrom/Row.Companion.of|(vararg(String(user_name).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(Alice)), String(email_address).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(alice@example.com)), String(age).R|kotlin/to|<R|kotlin/String|, R|kotlin/Int|>(Int(30)))), R|<local>/mikrom|)
+        R|kotlin/test/assertEquals|<R|DbUser|>(R|<local>/user|, R|/DbUser.DbUser|(String(Alice), String(alice@example.com), Int(30)))
+        ^box String(OK)
+    }
+    @R|io/github/kantis/mikrom/generator/RowMapped|() public final data class DbUser : R|kotlin/Any| {
+        public constructor(@R|io/github/kantis/mikrom/generator/Column|(name = String(user_name)) name: R|kotlin/String|, @R|io/github/kantis/mikrom/generator/Column|(name = String(email_address)) email: R|kotlin/String|, age: R|kotlin/Int|): R|DbUser| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val name: R|kotlin/String| = R|<local>/name|
+            public get(): R|kotlin/String|
+
+        public final val email: R|kotlin/String| = R|<local>/email|
+            public get(): R|kotlin/String|
+
+        public final val age: R|kotlin/Int| = R|<local>/age|
+            public get(): R|kotlin/Int|
+
+        public final operator fun component1(): R|kotlin/String|
+
+        public final operator fun component2(): R|kotlin/String|
+
+        public final operator fun component3(): R|kotlin/Int|
+
+        public final fun copy(@R|io/github/kantis/mikrom/generator/Column|(name = String(user_name)) name: R|kotlin/String| = this@R|/DbUser|.R|/DbUser.name|, @R|io/github/kantis/mikrom/generator/Column|(name = String(email_address)) email: R|kotlin/String| = this@R|/DbUser|.R|/DbUser.email|, age: R|kotlin/Int| = this@R|/DbUser|.R|/DbUser.age|): R|DbUser|
+
+        public final object $RowMapper : R|io/github/kantis/mikrom/RowMapper<DbUser>| {
+            public final fun mapRow(row: R|io/github/kantis/mikrom/Row|, mikrom: R|io/github/kantis/mikrom/Mikrom|): R|DbUser|
+
+            private constructor(): R|DbUser.$RowMapper|
+
+        }
+
+        public final companion object Companion : R|kotlin/Any| {
+            public final fun rowMapper(): R|io/github/kantis/mikrom/RowMapper<DbUser>|
+
+            private constructor(): R|DbUser.Companion|
+
+        }
+
+    }

--- a/mikrom-compiler-plugin/testData/box/ColumnAnnotation.kt
+++ b/mikrom-compiler-plugin/testData/box/ColumnAnnotation.kt
@@ -1,0 +1,31 @@
+// FIR_DUMP
+// DUMP_IR
+
+import io.github.kantis.mikrom.Mikrom
+import io.github.kantis.mikrom.Row
+import io.github.kantis.mikrom.TypeConversions
+import io.github.kantis.mikrom.generator.Column
+import io.github.kantis.mikrom.generator.RowMapped
+import kotlin.test.*
+
+fun box(): String {
+   val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+   val user = DbUser.rowMapper().mapRow(
+      Row.of(
+         "user_name" to "Alice",
+         "email_address" to "alice@example.com",
+         "age" to 30,
+      ),
+      mikrom,
+   )
+
+   assertEquals(user, DbUser("Alice", "alice@example.com", 30))
+   return "OK"
+}
+
+@RowMapped
+data class DbUser(
+   @Column("user_name") val name: String,
+   @Column("email_address") val email: String,
+   val age: Int,
+)

--- a/mikrom/mikrom-core/api/mikrom-core.api
+++ b/mikrom/mikrom-core/api/mikrom-core.api
@@ -152,6 +152,10 @@ public final class io/github/kantis/mikrom/datasource/Transaction$DefaultImpls {
 	public static synthetic fun query-Mwax8gE$default (Lio/github/kantis/mikrom/datasource/Transaction;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ljava/util/List;
 }
 
+public abstract interface annotation class io/github/kantis/mikrom/generator/Column : java/lang/annotation/Annotation {
+	public abstract fun name ()Ljava/lang/String;
+}
+
 public abstract interface class io/github/kantis/mikrom/generator/GeneratedRowMapper : io/github/kantis/mikrom/RowMapper {
 }
 

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/generator/Column.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/generator/Column.kt
@@ -1,0 +1,9 @@
+package io.github.kantis.mikrom.generator
+
+/**
+ * Specifies a custom column name for the annotated parameter when mapping database rows.
+ * If not present, the parameter name is used as the column name.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+public annotation class Column(val name: String)


### PR DESCRIPTION
## Summary
- Add `@Column(name)` annotation to `mikrom-core` for specifying custom database column names on `@RowMapped` data class parameters
- Update the compiler plugin IR visitor to read `@Column` annotations and use the specified name instead of the Kotlin parameter name
- Add box test verifying that `@Column`-annotated parameters map to the correct column names

## Test plan
- [x] New `ColumnAnnotation` box test passes — verifies `@Column("user_name")` and `@Column("email_address")` map correctly while unannotated `age` still uses its parameter name
- [x] All existing tests continue to pass (`./gradlew :mikrom-compiler-plugin:test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)