### PR TITLE
Add NamingStrategy for automatic column name mapping

### DIFF
--- a/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/ir/MikromIrVisitor.kt
+++ b/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/ir/MikromIrVisitor.kt
@@ -24,11 +24,13 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.declarations.IrVariable
 import org.jetbrains.kotlin.ir.expressions.IrBody
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrInstanceInitializerCallImpl
 import org.jetbrains.kotlin.ir.types.classifierOrNull
@@ -58,6 +60,8 @@ internal class MikromIrVisitor(
       private val ROW_CLASS_ID = ClassId(FqName("io.github.kantis.mikrom"), Name.identifier("Row"))
       private val ROW_MAPPER_NESTED_NAME = Name.identifier("\$RowMapper")
 
+      private val MIKROM_CLASS_ID = ClassId(FqName("io.github.kantis.mikrom"), Name.identifier("Mikrom"))
+      private val NAMING_STRATEGY_CLASS_ID = ClassId(FqName("io.github.kantis.mikrom"), Name.identifier("NamingStrategy"))
       private val COLUMN_CLASS_ID = ClassId(FqName("io.github.kantis.mikrom.generator"), Name.identifier("Column"))
 
       private val ILLEGAL_STATE_EXCEPTION_FQ_NAME =
@@ -65,6 +69,21 @@ internal class MikromIrVisitor(
 
       private val ILLEGAL_STATE_EXCEPTION_CLASS_ID =
          ClassId.topLevel(ILLEGAL_STATE_EXCEPTION_FQ_NAME)
+   }
+
+   private val namingStrategyGetter by lazy {
+      val mikromClass = pluginContext.referenceClass(MIKROM_CLASS_ID)!!
+      mikromClass.owner.declarations
+         .filterIsInstance<IrProperty>()
+         .single { it.name.asString() == "namingStrategy" }
+         .getter!!.symbol
+   }
+
+   private val toColumnNameFunction by lazy {
+      val nsClass = pluginContext.referenceClass(NAMING_STRATEGY_CLASS_ID)!!
+      nsClass.functions.single {
+         it.owner.name.asString() == "toColumnName"
+      }
    }
 
    private val nullableStringType = pluginContext.irBuiltIns.stringType.makeNullable()
@@ -213,7 +232,7 @@ internal class MikromIrVisitor(
             value = irBlock {
                val rowRef = irGet(row)
                val mikromRef = irGet(mikrom)
-               val keyLiteral = irString(columnName(valueParameter))
+               val keyExpr = columnNameExpression(valueParameter, mikrom)
 
                val classRef = IrClassReferenceImpl(
                   startOffset,
@@ -227,7 +246,7 @@ internal class MikromIrVisitor(
                   dispatchReceiver = rowRef
                   typeArguments[0] = baseType
                   arguments[1] = mikromRef
-                  arguments[2] = keyLiteral
+                  arguments[2] = keyExpr
                   arguments[3] = classRef
                }
             },
@@ -237,13 +256,25 @@ internal class MikromIrVisitor(
       return variables
    }
 
-   private fun columnName(valueParameter: IrValueParameter): String {
+   private fun IrBuilderWithScope.columnNameExpression(
+      valueParameter: IrValueParameter,
+      mikrom: IrValueParameter,
+   ): IrExpression {
       val columnAnnotation = valueParameter.annotations.firstOrNull {
          it.type.classifierOrNull == pluginContext.referenceClass(COLUMN_CLASS_ID)
-      } ?: return valueParameter.name.asString()
+      }
 
-      val nameArg = columnAnnotation.arguments[0]
-      return (nameArg as? org.jetbrains.kotlin.ir.expressions.IrConst)?.value as? String
-         ?: valueParameter.name.asString()
+      if (columnAnnotation != null) {
+         val nameArg = columnAnnotation.arguments[0]
+         val explicitName = (nameArg as? org.jetbrains.kotlin.ir.expressions.IrConst)?.value as? String
+         if (explicitName != null) return irString(explicitName)
+      }
+
+      return irCall(toColumnNameFunction).apply {
+         dispatchReceiver = irCall(namingStrategyGetter).apply {
+            dispatchReceiver = irGet(mikrom)
+         }
+         arguments[1] = irString(valueParameter.name.asString())
+      }
    }
 }

--- a/mikrom-compiler-plugin/test-gen/io/github/kantis/mikrom/plugin/BoxTestGenerated.java
+++ b/mikrom-compiler-plugin/test-gen/io/github/kantis/mikrom/plugin/BoxTestGenerated.java
@@ -27,6 +27,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
   }
 
   @Test
+  @TestMetadata("NamingStrategy.kt")
+  public void testNamingStrategy() {
+    runTest("testData/box/NamingStrategy.kt");
+  }
+
+  @Test
   @TestMetadata("NullableValueClass.kt")
   public void testNullableValueClass() {
     runTest("testData/box/NullableValueClass.kt");

--- a/mikrom-compiler-plugin/testData/box/ColumnAnnotation.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/ColumnAnnotation.fir.ir.txt
@@ -108,7 +108,10 @@ FILE fqName:<root> fileName:/ColumnAnnotation.kt
                 TYPE_ARG T: kotlin.Int
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.DbUser.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
                 ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.DbUser.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
-                ARG column: CONST String type=kotlin.String value="age"
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.DbUser.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="age"
                 ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.Int>
           RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.DbUser declared in <root>.DbUser.$RowMapper'
             CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, email: kotlin.String, age: kotlin.Int) declared in <root>.DbUser' type=<root>.DbUser origin=null
@@ -272,7 +275,7 @@ FILE fqName:<root> fileName:/ColumnAnnotation.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions, namingStrategy: io.github.kantis.mikrom.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>

--- a/mikrom-compiler-plugin/testData/box/NamingStrategy.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/NamingStrategy.fir.ir.txt
@@ -1,0 +1,671 @@
+FILE fqName:<root> fileName:/NamingStrategy.kt
+  CLASS CLASS name:AsIsEntity modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
+    annotations:
+      RowMapped
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.AsIsEntity
+    PROPERTY name:firstName visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:firstName type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'firstName: kotlin.String declared in <root>.AsIsEntity.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-firstName> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.AsIsEntity
+        correspondingProperty: PROPERTY name:firstName visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-firstName> (): kotlin.String declared in <root>.AsIsEntity'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:firstName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.AsIsEntity declared in <root>.AsIsEntity.<get-firstName>' type=<root>.AsIsEntity origin=null
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.AsIsEntity.Companion
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] visibility:private returnType:<root>.AsIsEntity.Companion [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperAccessorKey] name:rowMapper visibility:public modality:FINAL returnType:io.github.kantis.mikrom.RowMapper<<root>.AsIsEntity>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.AsIsEntity.Companion
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun rowMapper (): io.github.kantis.mikrom.RowMapper<<root>.AsIsEntity> declared in <root>.AsIsEntity.Companion'
+            GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.AsIsEntity>]' type=<root>.AsIsEntity.$RowMapper
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.AsIsEntity>]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.AsIsEntity.$RowMapper
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] visibility:private returnType:<root>.AsIsEntity.$RowMapper [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.AsIsEntity>]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in io.github.kantis.mikrom.RowMapper
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in io.github.kantis.mikrom.RowMapper
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in io.github.kantis.mikrom.RowMapper
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] name:mapRow visibility:public modality:FINAL returnType:<root>.AsIsEntity
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.AsIsEntity.$RowMapper
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:row index:1 type:io.github.kantis.mikrom.Row
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:mikrom index:2 type:io.github.kantis.mikrom.Mikrom
+        overridden:
+          public abstract fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper
+        BLOCK_BODY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.String
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.AsIsEntity.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.AsIsEntity.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.AsIsEntity.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="firstName"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+          RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.AsIsEntity declared in <root>.AsIsEntity.$RowMapper'
+            CONSTRUCTOR_CALL 'public constructor <init> (firstName: kotlin.String) declared in <root>.AsIsEntity' type=<root>.AsIsEntity origin=null
+              ARG firstName: GET_VAR 'val tmp_0: T of io.github.kantis.mikrom.Row.get declared in <root>.AsIsEntity.$RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.AsIsEntity [primary]
+      VALUE_PARAMETER kind:Regular name:firstName index:0 type:kotlin.String
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:AsIsEntity modality:FINAL visibility:public [data] superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.AsIsEntity
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.AsIsEntity'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:firstName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.AsIsEntity declared in <root>.AsIsEntity.component1' type=<root>.AsIsEntity origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL returnType:<root>.AsIsEntity
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.AsIsEntity
+      VALUE_PARAMETER kind:Regular name:firstName index:1 type:kotlin.String
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:firstName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.AsIsEntity declared in <root>.AsIsEntity.copy' type=<root>.AsIsEntity origin=null
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun copy (firstName: kotlin.String): <root>.AsIsEntity declared in <root>.AsIsEntity'
+          CONSTRUCTOR_CALL 'public constructor <init> (firstName: kotlin.String) declared in <root>.AsIsEntity' type=<root>.AsIsEntity origin=null
+            ARG firstName: GET_VAR 'firstName: kotlin.String declared in <root>.AsIsEntity.copy' type=kotlin.String origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.AsIsEntity
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+              ARG arg0: GET_VAR '<this>: <root>.AsIsEntity declared in <root>.AsIsEntity.equals' type=<root>.AsIsEntity origin=null
+              ARG arg1: GET_VAR 'other: kotlin.Any? declared in <root>.AsIsEntity.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.AsIsEntity'
+              CONST Boolean type=kotlin.Boolean value=true
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.AsIsEntity
+              GET_VAR 'other: kotlin.Any? declared in <root>.AsIsEntity.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.AsIsEntity'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:<root>.AsIsEntity [val]
+          TYPE_OP type=<root>.AsIsEntity origin=IMPLICIT_CAST typeOperand=<root>.AsIsEntity
+            GET_VAR 'other: kotlin.Any? declared in <root>.AsIsEntity.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:firstName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.AsIsEntity declared in <root>.AsIsEntity.equals' type=<root>.AsIsEntity origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:firstName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_1: <root>.AsIsEntity declared in <root>.AsIsEntity.equals' type=<root>.AsIsEntity origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.AsIsEntity'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.AsIsEntity'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.AsIsEntity
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.AsIsEntity'
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:firstName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.AsIsEntity declared in <root>.AsIsEntity.hashCode' type=<root>.AsIsEntity origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.AsIsEntity
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.AsIsEntity'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="AsIsEntity("
+            CONST String type=kotlin.String value="firstName="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:firstName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.AsIsEntity declared in <root>.AsIsEntity.toString' type=<root>.AsIsEntity origin=null
+            CONST String type=kotlin.String value=")"
+  CLASS CLASS name:Invoice modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
+    annotations:
+      RowMapped
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Invoice
+    PROPERTY name:invoiceId visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:invoiceId type:kotlin.Int visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'invoiceId: kotlin.Int declared in <root>.Invoice.<init>' type=kotlin.Int origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-invoiceId> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice
+        correspondingProperty: PROPERTY name:invoiceId visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-invoiceId> (): kotlin.Int declared in <root>.Invoice'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:invoiceId type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.<get-invoiceId>' type=<root>.Invoice origin=null
+    PROPERTY name:customerName visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:customerName type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'customerName: kotlin.String declared in <root>.Invoice.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-customerName> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice
+        correspondingProperty: PROPERTY name:customerName visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-customerName> (): kotlin.String declared in <root>.Invoice'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:customerName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.<get-customerName>' type=<root>.Invoice origin=null
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Invoice.Companion
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] visibility:private returnType:<root>.Invoice.Companion [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperAccessorKey] name:rowMapper visibility:public modality:FINAL returnType:io.github.kantis.mikrom.RowMapper<<root>.Invoice>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice.Companion
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun rowMapper (): io.github.kantis.mikrom.RowMapper<<root>.Invoice> declared in <root>.Invoice.Companion'
+            GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.Invoice>]' type=<root>.Invoice.$RowMapper
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.Invoice>]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Invoice.$RowMapper
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] visibility:private returnType:<root>.Invoice.$RowMapper [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.Invoice>]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in io.github.kantis.mikrom.RowMapper
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in io.github.kantis.mikrom.RowMapper
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in io.github.kantis.mikrom.RowMapper
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] name:mapRow visibility:public modality:FINAL returnType:<root>.Invoice
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice.$RowMapper
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:row index:1 type:io.github.kantis.mikrom.Row
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:mikrom index:2 type:io.github.kantis.mikrom.Mikrom
+        overridden:
+          public abstract fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper
+        BLOCK_BODY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.Int
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Invoice.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Invoice.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Invoice.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="invoiceId"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.Int>
+          VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.String
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Invoice.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Invoice.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Invoice.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="customerName"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+          RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.Invoice declared in <root>.Invoice.$RowMapper'
+            CONSTRUCTOR_CALL 'public constructor <init> (invoiceId: kotlin.Int, customerName: kotlin.String) declared in <root>.Invoice' type=<root>.Invoice origin=null
+              ARG invoiceId: GET_VAR 'val tmp_2: T of io.github.kantis.mikrom.Row.get declared in <root>.Invoice.$RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
+              ARG customerName: GET_VAR 'val tmp_3: T of io.github.kantis.mikrom.Row.get declared in <root>.Invoice.$RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.Invoice [primary]
+      VALUE_PARAMETER kind:Regular name:invoiceId index:0 type:kotlin.Int
+      VALUE_PARAMETER kind:Regular name:customerName index:1 type:kotlin.String
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Invoice modality:FINAL visibility:public [data] superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL returnType:kotlin.Int [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.Int declared in <root>.Invoice'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:invoiceId type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.component1' type=<root>.Invoice origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:component2 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.String declared in <root>.Invoice'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:customerName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.component2' type=<root>.Invoice origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL returnType:<root>.Invoice
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice
+      VALUE_PARAMETER kind:Regular name:invoiceId index:1 type:kotlin.Int
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:invoiceId type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.copy' type=<root>.Invoice origin=null
+      VALUE_PARAMETER kind:Regular name:customerName index:2 type:kotlin.String
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:customerName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.copy' type=<root>.Invoice origin=null
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun copy (invoiceId: kotlin.Int, customerName: kotlin.String): <root>.Invoice declared in <root>.Invoice'
+          CONSTRUCTOR_CALL 'public constructor <init> (invoiceId: kotlin.Int, customerName: kotlin.String) declared in <root>.Invoice' type=<root>.Invoice origin=null
+            ARG invoiceId: GET_VAR 'invoiceId: kotlin.Int declared in <root>.Invoice.copy' type=kotlin.Int origin=null
+            ARG customerName: GET_VAR 'customerName: kotlin.String declared in <root>.Invoice.copy' type=kotlin.String origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+              ARG arg0: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.equals' type=<root>.Invoice origin=null
+              ARG arg1: GET_VAR 'other: kotlin.Any? declared in <root>.Invoice.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Invoice'
+              CONST Boolean type=kotlin.Boolean value=true
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.Invoice
+              GET_VAR 'other: kotlin.Any? declared in <root>.Invoice.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Invoice'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:<root>.Invoice [val]
+          TYPE_OP type=<root>.Invoice origin=IMPLICIT_CAST typeOperand=<root>.Invoice
+            GET_VAR 'other: kotlin.Any? declared in <root>.Invoice.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:invoiceId type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                  receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.equals' type=<root>.Invoice origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:invoiceId type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                  receiver: GET_VAR 'val tmp_4: <root>.Invoice declared in <root>.Invoice.equals' type=<root>.Invoice origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Invoice'
+              CONST Boolean type=kotlin.Boolean value=false
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:customerName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.equals' type=<root>.Invoice origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:customerName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_4: <root>.Invoice declared in <root>.Invoice.equals' type=<root>.Invoice origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Invoice'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Invoice'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      BLOCK_BODY
+        VAR name:result type:kotlin.Int [var]
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:invoiceId type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.hashCode' type=<root>.Invoice origin=null
+        SET_VAR 'var result: kotlin.Int declared in <root>.Invoice.hashCode' type=kotlin.Unit origin=EQ
+          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'var result: kotlin.Int declared in <root>.Invoice.hashCode' type=kotlin.Int origin=null
+              ARG other: CONST Int type=kotlin.Int value=31
+            ARG other: CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+              ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:customerName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.hashCode' type=<root>.Invoice origin=null
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.Invoice'
+          GET_VAR 'var result: kotlin.Int declared in <root>.Invoice.hashCode' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Invoice
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.Invoice'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="Invoice("
+            CONST String type=kotlin.String value="invoiceId="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:invoiceId type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.toString' type=<root>.Invoice origin=null
+            CONST String type=kotlin.String value=", "
+            CONST String type=kotlin.String value="customerName="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:customerName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Invoice declared in <root>.Invoice.toString' type=<root>.Invoice origin=null
+            CONST String type=kotlin.String value=")"
+  CLASS CLASS name:OverriddenEntity modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
+    annotations:
+      RowMapped
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.OverriddenEntity
+    PROPERTY name:name visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'name: kotlin.String declared in <root>.OverriddenEntity.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity
+        correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String declared in <root>.OverriddenEntity'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.<get-name>' type=<root>.OverriddenEntity origin=null
+    PROPERTY name:otherField visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:otherField type:kotlin.Int visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'otherField: kotlin.Int declared in <root>.OverriddenEntity.<init>' type=kotlin.Int origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-otherField> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity
+        correspondingProperty: PROPERTY name:otherField visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-otherField> (): kotlin.Int declared in <root>.OverriddenEntity'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:otherField type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.<get-otherField>' type=<root>.OverriddenEntity origin=null
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.OverriddenEntity.Companion
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] visibility:private returnType:<root>.OverriddenEntity.Companion [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperAccessorKey] name:rowMapper visibility:public modality:FINAL returnType:io.github.kantis.mikrom.RowMapper<<root>.OverriddenEntity>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity.Companion
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun rowMapper (): io.github.kantis.mikrom.RowMapper<<root>.OverriddenEntity> declared in <root>.OverriddenEntity.Companion'
+            GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.OverriddenEntity>]' type=<root>.OverriddenEntity.$RowMapper
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.OverriddenEntity>]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.OverriddenEntity.$RowMapper
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] visibility:private returnType:<root>.OverriddenEntity.$RowMapper [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperClassKey] OBJECT name:$RowMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.RowMapper<<root>.OverriddenEntity>]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in io.github.kantis.mikrom.RowMapper
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in io.github.kantis.mikrom.RowMapper
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in io.github.kantis.mikrom.RowMapper
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] name:mapRow visibility:public modality:FINAL returnType:<root>.OverriddenEntity
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity.$RowMapper
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:row index:1 type:io.github.kantis.mikrom.Row
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateRowMapperKey] kind:Regular name:mikrom index:2 type:io.github.kantis.mikrom.Mikrom
+        overridden:
+          public abstract fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper
+        BLOCK_BODY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.String
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.OverriddenEntity.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.OverriddenEntity.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                ARG column: CONST String type=kotlin.String value="custom_col"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+          VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:T of io.github.kantis.mikrom.Row.get [val]
+            BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
+              CALL 'public final fun get <T> (mikrom: io.github.kantis.mikrom.Mikrom, column: kotlin.String, clazz: kotlin.reflect.KClass<*>): T of io.github.kantis.mikrom.Row.get declared in io.github.kantis.mikrom.Row' type=T of io.github.kantis.mikrom.Row.get origin=null
+                TYPE_ARG T: kotlin.Int
+                ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.OverriddenEntity.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
+                ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.OverriddenEntity.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.OverriddenEntity.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="otherField"
+                ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.Int>
+          RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.OverriddenEntity declared in <root>.OverriddenEntity.$RowMapper'
+            CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, otherField: kotlin.Int) declared in <root>.OverriddenEntity' type=<root>.OverriddenEntity origin=null
+              ARG name: GET_VAR 'val tmp_5: T of io.github.kantis.mikrom.Row.get declared in <root>.OverriddenEntity.$RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
+              ARG otherField: GET_VAR 'val tmp_6: T of io.github.kantis.mikrom.Row.get declared in <root>.OverriddenEntity.$RowMapper.mapRow' type=T of io.github.kantis.mikrom.Row.get origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.OverriddenEntity [primary]
+      VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
+        annotations:
+          Column(name = "custom_col")
+      VALUE_PARAMETER kind:Regular name:otherField index:1 type:kotlin.Int
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:OverriddenEntity modality:FINAL visibility:public [data] superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.OverriddenEntity'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.component1' type=<root>.OverriddenEntity origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:component2 visibility:public modality:FINAL returnType:kotlin.Int [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.Int declared in <root>.OverriddenEntity'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:otherField type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.component2' type=<root>.OverriddenEntity origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL returnType:<root>.OverriddenEntity
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+        annotations:
+          Column(name = "custom_col")
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.copy' type=<root>.OverriddenEntity origin=null
+      VALUE_PARAMETER kind:Regular name:otherField index:2 type:kotlin.Int
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:otherField type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+            receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.copy' type=<root>.OverriddenEntity origin=null
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun copy (name: kotlin.String, otherField: kotlin.Int): <root>.OverriddenEntity declared in <root>.OverriddenEntity'
+          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, otherField: kotlin.Int) declared in <root>.OverriddenEntity' type=<root>.OverriddenEntity origin=null
+            ARG name: GET_VAR 'name: kotlin.String declared in <root>.OverriddenEntity.copy' type=kotlin.String origin=null
+            ARG otherField: GET_VAR 'otherField: kotlin.Int declared in <root>.OverriddenEntity.copy' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+              ARG arg0: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.equals' type=<root>.OverriddenEntity origin=null
+              ARG arg1: GET_VAR 'other: kotlin.Any? declared in <root>.OverriddenEntity.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.OverriddenEntity'
+              CONST Boolean type=kotlin.Boolean value=true
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.OverriddenEntity
+              GET_VAR 'other: kotlin.Any? declared in <root>.OverriddenEntity.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.OverriddenEntity'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:<root>.OverriddenEntity [val]
+          TYPE_OP type=<root>.OverriddenEntity origin=IMPLICIT_CAST typeOperand=<root>.OverriddenEntity
+            GET_VAR 'other: kotlin.Any? declared in <root>.OverriddenEntity.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.equals' type=<root>.OverriddenEntity origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_7: <root>.OverriddenEntity declared in <root>.OverriddenEntity.equals' type=<root>.OverriddenEntity origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.OverriddenEntity'
+              CONST Boolean type=kotlin.Boolean value=false
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:otherField type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                  receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.equals' type=<root>.OverriddenEntity origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:otherField type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                  receiver: GET_VAR 'val tmp_7: <root>.OverriddenEntity declared in <root>.OverriddenEntity.equals' type=<root>.OverriddenEntity origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.OverriddenEntity'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.OverriddenEntity'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      BLOCK_BODY
+        VAR name:result type:kotlin.Int [var]
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.hashCode' type=<root>.OverriddenEntity origin=null
+        SET_VAR 'var result: kotlin.Int declared in <root>.OverriddenEntity.hashCode' type=kotlin.Unit origin=EQ
+          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'var result: kotlin.Int declared in <root>.OverriddenEntity.hashCode' type=kotlin.Int origin=null
+              ARG other: CONST Int type=kotlin.Int value=31
+            ARG other: CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:otherField type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+                receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.hashCode' type=<root>.OverriddenEntity origin=null
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.OverriddenEntity'
+          GET_VAR 'var result: kotlin.Int declared in <root>.OverriddenEntity.hashCode' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.OverriddenEntity
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.OverriddenEntity'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="OverriddenEntity("
+            CONST String type=kotlin.String value="name="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.toString' type=<root>.OverriddenEntity origin=null
+            CONST String type=kotlin.String value=", "
+            CONST String type=kotlin.String value="otherField="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:otherField type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: <root>.OverriddenEntity declared in <root>.OverriddenEntity.toString' type=<root>.OverriddenEntity origin=null
+            CONST String type=kotlin.String value=")"
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:snakeMikrom type:io.github.kantis.mikrom.Mikrom [val]
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions, namingStrategy: io.github.kantis.mikrom.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+          ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
+            TYPE_ARG K: kotlin.reflect.KClass<*>
+            TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>
+          ARG conversions: CALL 'public final fun <get-EMPTY> (): io.github.kantis.mikrom.TypeConversions declared in io.github.kantis.mikrom.TypeConversions.Companion' type=io.github.kantis.mikrom.TypeConversions origin=GET_PROPERTY
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.TypeConversions.Companion
+      VAR name:invoice type:<root>.Invoice [val]
+        CALL 'public abstract fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper' type=<root>.Invoice origin=null
+          ARG <this>: CALL 'public final fun rowMapper (): io.github.kantis.mikrom.RowMapper<<root>.Invoice> declared in <root>.Invoice.Companion' type=io.github.kantis.mikrom.RowMapper<<root>.Invoice> origin=null
+            ARG <this>: GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=<root>.Invoice.Companion
+          ARG row: CALL 'public final fun of (vararg pairs: kotlin.Pair<kotlin.String, kotlin.Any?>): io.github.kantis.mikrom.Row declared in io.github.kantis.mikrom.Row.Companion' type=io.github.kantis.mikrom.Row origin=null
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.Row.Companion
+            ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlin.Any?>> varargElementType=kotlin.Pair<kotlin.String, kotlin.Any?>
+              CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlin.Int> origin=null
+                TYPE_ARG A: kotlin.String
+                TYPE_ARG B: kotlin.Int
+                ARG <this>: CONST String type=kotlin.String value="invoice_id"
+                ARG that: CONST Int type=kotlin.Int value=42
+              CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlin.String> origin=null
+                TYPE_ARG A: kotlin.String
+                TYPE_ARG B: kotlin.String
+                ARG <this>: CONST String type=kotlin.String value="customer_name"
+                ARG that: CONST String type=kotlin.String value="Alice"
+          ARG mikrom: GET_VAR 'val snakeMikrom: io.github.kantis.mikrom.Mikrom declared in <root>.box' type=io.github.kantis.mikrom.Mikrom origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: <root>.Invoice
+        ARG expected: CONSTRUCTOR_CALL 'public constructor <init> (invoiceId: kotlin.Int, customerName: kotlin.String) declared in <root>.Invoice' type=<root>.Invoice origin=null
+          ARG invoiceId: CONST Int type=kotlin.Int value=42
+          ARG customerName: CONST String type=kotlin.String value="Alice"
+        ARG actual: GET_VAR 'val invoice: <root>.Invoice declared in <root>.box' type=<root>.Invoice origin=null
+      VAR name:overridden type:<root>.OverriddenEntity [val]
+        CALL 'public abstract fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper' type=<root>.OverriddenEntity origin=null
+          ARG <this>: CALL 'public final fun rowMapper (): io.github.kantis.mikrom.RowMapper<<root>.OverriddenEntity> declared in <root>.OverriddenEntity.Companion' type=io.github.kantis.mikrom.RowMapper<<root>.OverriddenEntity> origin=null
+            ARG <this>: GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=<root>.OverriddenEntity.Companion
+          ARG row: CALL 'public final fun of (vararg pairs: kotlin.Pair<kotlin.String, kotlin.Any?>): io.github.kantis.mikrom.Row declared in io.github.kantis.mikrom.Row.Companion' type=io.github.kantis.mikrom.Row origin=null
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.Row.Companion
+            ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlin.Any?>> varargElementType=kotlin.Pair<kotlin.String, kotlin.Any?>
+              CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlin.String> origin=null
+                TYPE_ARG A: kotlin.String
+                TYPE_ARG B: kotlin.String
+                ARG <this>: CONST String type=kotlin.String value="custom_col"
+                ARG that: CONST String type=kotlin.String value="hello"
+              CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlin.Int> origin=null
+                TYPE_ARG A: kotlin.String
+                TYPE_ARG B: kotlin.Int
+                ARG <this>: CONST String type=kotlin.String value="other_field"
+                ARG that: CONST Int type=kotlin.Int value=99
+          ARG mikrom: GET_VAR 'val snakeMikrom: io.github.kantis.mikrom.Mikrom declared in <root>.box' type=io.github.kantis.mikrom.Mikrom origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: <root>.OverriddenEntity
+        ARG expected: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, otherField: kotlin.Int) declared in <root>.OverriddenEntity' type=<root>.OverriddenEntity origin=null
+          ARG name: CONST String type=kotlin.String value="hello"
+          ARG otherField: CONST Int type=kotlin.Int value=99
+        ARG actual: GET_VAR 'val overridden: <root>.OverriddenEntity declared in <root>.box' type=<root>.OverriddenEntity origin=null
+      VAR name:asIsMikrom type:io.github.kantis.mikrom.Mikrom [val]
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions, namingStrategy: io.github.kantis.mikrom.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+          ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
+            TYPE_ARG K: kotlin.reflect.KClass<*>
+            TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>
+          ARG conversions: CALL 'public final fun <get-EMPTY> (): io.github.kantis.mikrom.TypeConversions declared in io.github.kantis.mikrom.TypeConversions.Companion' type=io.github.kantis.mikrom.TypeConversions origin=GET_PROPERTY
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.TypeConversions.Companion
+          ARG namingStrategy: CALL 'public final fun <get-AS_IS> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.NamingStrategy.Companion' type=io.github.kantis.mikrom.NamingStrategy origin=GET_PROPERTY
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.NamingStrategy.Companion
+      VAR name:entity type:<root>.AsIsEntity [val]
+        CALL 'public abstract fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): T of io.github.kantis.mikrom.RowMapper declared in io.github.kantis.mikrom.RowMapper' type=<root>.AsIsEntity origin=null
+          ARG <this>: CALL 'public final fun rowMapper (): io.github.kantis.mikrom.RowMapper<<root>.AsIsEntity> declared in <root>.AsIsEntity.Companion' type=io.github.kantis.mikrom.RowMapper<<root>.AsIsEntity> origin=null
+            ARG <this>: GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=<root>.AsIsEntity.Companion
+          ARG row: CALL 'public final fun of (vararg pairs: kotlin.Pair<kotlin.String, kotlin.Any?>): io.github.kantis.mikrom.Row declared in io.github.kantis.mikrom.Row.Companion' type=io.github.kantis.mikrom.Row origin=null
+            ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=io.github.kantis.mikrom.Row.Companion
+            ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlin.Any?>> varargElementType=kotlin.Pair<kotlin.String, kotlin.Any?>
+              CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlin.String> origin=null
+                TYPE_ARG A: kotlin.String
+                TYPE_ARG B: kotlin.String
+                ARG <this>: CONST String type=kotlin.String value="firstName"
+                ARG that: CONST String type=kotlin.String value="Bob"
+          ARG mikrom: GET_VAR 'val asIsMikrom: io.github.kantis.mikrom.Mikrom declared in <root>.box' type=io.github.kantis.mikrom.Mikrom origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: <root>.AsIsEntity
+        ARG expected: CONSTRUCTOR_CALL 'public constructor <init> (firstName: kotlin.String) declared in <root>.AsIsEntity' type=<root>.AsIsEntity origin=null
+          ARG firstName: CONST String type=kotlin.String value="Bob"
+        ARG actual: GET_VAR 'val entity: <root>.AsIsEntity declared in <root>.box' type=<root>.AsIsEntity origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/mikrom-compiler-plugin/testData/box/NamingStrategy.fir.txt
+++ b/mikrom-compiler-plugin/testData/box/NamingStrategy.fir.txt
@@ -1,0 +1,103 @@
+FILE: NamingStrategy.kt
+    public final fun box(): R|kotlin/String| {
+        lval snakeMikrom: R|io/github/kantis/mikrom/Mikrom| = R|io/github/kantis/mikrom/Mikrom.Mikrom|(R|kotlin/collections/mutableMapOf|<R|kotlin/reflect/KClass<*>|, R|io/github/kantis/mikrom/RowMapper<*>|>(), Q|io/github/kantis/mikrom/TypeConversions|.R|io/github/kantis/mikrom/TypeConversions.Companion.EMPTY|)
+        lval invoice: R|Invoice| = Q|Invoice|.R|/Invoice.Companion.rowMapper|().R|SubstitutionOverride<io/github/kantis/mikrom/RowMapper.mapRow: R|Invoice|>|(Q|io/github/kantis/mikrom/Row|.R|io/github/kantis/mikrom/Row.Companion.of|(vararg(String(invoice_id).R|kotlin/to|<R|kotlin/String|, R|kotlin/Int|>(Int(42)), String(customer_name).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(Alice)))), R|<local>/snakeMikrom|)
+        R|kotlin/test/assertEquals|<R|Invoice|>(R|/Invoice.Invoice|(Int(42), String(Alice)), R|<local>/invoice|)
+        lval overridden: R|OverriddenEntity| = Q|OverriddenEntity|.R|/OverriddenEntity.Companion.rowMapper|().R|SubstitutionOverride<io/github/kantis/mikrom/RowMapper.mapRow: R|OverriddenEntity|>|(Q|io/github/kantis/mikrom/Row|.R|io/github/kantis/mikrom/Row.Companion.of|(vararg(String(custom_col).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(hello)), String(other_field).R|kotlin/to|<R|kotlin/String|, R|kotlin/Int|>(Int(99)))), R|<local>/snakeMikrom|)
+        R|kotlin/test/assertEquals|<R|OverriddenEntity|>(R|/OverriddenEntity.OverriddenEntity|(String(hello), Int(99)), R|<local>/overridden|)
+        lval asIsMikrom: R|io/github/kantis/mikrom/Mikrom| = R|io/github/kantis/mikrom/Mikrom.Mikrom|(R|kotlin/collections/mutableMapOf|<R|kotlin/reflect/KClass<*>|, R|io/github/kantis/mikrom/RowMapper<*>|>(), Q|io/github/kantis/mikrom/TypeConversions|.R|io/github/kantis/mikrom/TypeConversions.Companion.EMPTY|, Q|io/github/kantis/mikrom/NamingStrategy|.R|io/github/kantis/mikrom/NamingStrategy.Companion.AS_IS|)
+        lval entity: R|AsIsEntity| = Q|AsIsEntity|.R|/AsIsEntity.Companion.rowMapper|().R|SubstitutionOverride<io/github/kantis/mikrom/RowMapper.mapRow: R|AsIsEntity|>|(Q|io/github/kantis/mikrom/Row|.R|io/github/kantis/mikrom/Row.Companion.of|(vararg(String(firstName).R|kotlin/to|<R|kotlin/String|, R|kotlin/String|>(String(Bob)))), R|<local>/asIsMikrom|)
+        R|kotlin/test/assertEquals|<R|AsIsEntity|>(R|/AsIsEntity.AsIsEntity|(String(Bob)), R|<local>/entity|)
+        ^box String(OK)
+    }
+    @R|io/github/kantis/mikrom/generator/RowMapped|() public final data class Invoice : R|kotlin/Any| {
+        public constructor(invoiceId: R|kotlin/Int|, customerName: R|kotlin/String|): R|Invoice| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val invoiceId: R|kotlin/Int| = R|<local>/invoiceId|
+            public get(): R|kotlin/Int|
+
+        public final val customerName: R|kotlin/String| = R|<local>/customerName|
+            public get(): R|kotlin/String|
+
+        public final operator fun component1(): R|kotlin/Int|
+
+        public final operator fun component2(): R|kotlin/String|
+
+        public final fun copy(invoiceId: R|kotlin/Int| = this@R|/Invoice|.R|/Invoice.invoiceId|, customerName: R|kotlin/String| = this@R|/Invoice|.R|/Invoice.customerName|): R|Invoice|
+
+        public final object $RowMapper : R|io/github/kantis/mikrom/RowMapper<Invoice>| {
+            public final fun mapRow(row: R|io/github/kantis/mikrom/Row|, mikrom: R|io/github/kantis/mikrom/Mikrom|): R|Invoice|
+
+            private constructor(): R|Invoice.$RowMapper|
+
+        }
+
+        public final companion object Companion : R|kotlin/Any| {
+            public final fun rowMapper(): R|io/github/kantis/mikrom/RowMapper<Invoice>|
+
+            private constructor(): R|Invoice.Companion|
+
+        }
+
+    }
+    @R|io/github/kantis/mikrom/generator/RowMapped|() public final data class OverriddenEntity : R|kotlin/Any| {
+        public constructor(@R|io/github/kantis/mikrom/generator/Column|(name = String(custom_col)) name: R|kotlin/String|, otherField: R|kotlin/Int|): R|OverriddenEntity| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val name: R|kotlin/String| = R|<local>/name|
+            public get(): R|kotlin/String|
+
+        public final val otherField: R|kotlin/Int| = R|<local>/otherField|
+            public get(): R|kotlin/Int|
+
+        public final operator fun component1(): R|kotlin/String|
+
+        public final operator fun component2(): R|kotlin/Int|
+
+        public final fun copy(@R|io/github/kantis/mikrom/generator/Column|(name = String(custom_col)) name: R|kotlin/String| = this@R|/OverriddenEntity|.R|/OverriddenEntity.name|, otherField: R|kotlin/Int| = this@R|/OverriddenEntity|.R|/OverriddenEntity.otherField|): R|OverriddenEntity|
+
+        public final object $RowMapper : R|io/github/kantis/mikrom/RowMapper<OverriddenEntity>| {
+            public final fun mapRow(row: R|io/github/kantis/mikrom/Row|, mikrom: R|io/github/kantis/mikrom/Mikrom|): R|OverriddenEntity|
+
+            private constructor(): R|OverriddenEntity.$RowMapper|
+
+        }
+
+        public final companion object Companion : R|kotlin/Any| {
+            public final fun rowMapper(): R|io/github/kantis/mikrom/RowMapper<OverriddenEntity>|
+
+            private constructor(): R|OverriddenEntity.Companion|
+
+        }
+
+    }
+    @R|io/github/kantis/mikrom/generator/RowMapped|() public final data class AsIsEntity : R|kotlin/Any| {
+        public constructor(firstName: R|kotlin/String|): R|AsIsEntity| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val firstName: R|kotlin/String| = R|<local>/firstName|
+            public get(): R|kotlin/String|
+
+        public final operator fun component1(): R|kotlin/String|
+
+        public final fun copy(firstName: R|kotlin/String| = this@R|/AsIsEntity|.R|/AsIsEntity.firstName|): R|AsIsEntity|
+
+        public final object $RowMapper : R|io/github/kantis/mikrom/RowMapper<AsIsEntity>| {
+            public final fun mapRow(row: R|io/github/kantis/mikrom/Row|, mikrom: R|io/github/kantis/mikrom/Mikrom|): R|AsIsEntity|
+
+            private constructor(): R|AsIsEntity.$RowMapper|
+
+        }
+
+        public final companion object Companion : R|kotlin/Any| {
+            public final fun rowMapper(): R|io/github/kantis/mikrom/RowMapper<AsIsEntity>|
+
+            private constructor(): R|AsIsEntity.Companion|
+
+        }
+
+    }

--- a/mikrom-compiler-plugin/testData/box/NamingStrategy.kt
+++ b/mikrom-compiler-plugin/testData/box/NamingStrategy.kt
@@ -1,0 +1,62 @@
+// FIR_DUMP
+// DUMP_IR
+
+import io.github.kantis.mikrom.Mikrom
+import io.github.kantis.mikrom.NamingStrategy
+import io.github.kantis.mikrom.Row
+import io.github.kantis.mikrom.TypeConversions
+import io.github.kantis.mikrom.generator.Column
+import io.github.kantis.mikrom.generator.RowMapped
+import kotlin.test.*
+
+fun box(): String {
+   // Test SNAKE_CASE (default)
+   val snakeMikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+   val invoice = Invoice.rowMapper().mapRow(
+      Row.of(
+         "invoice_id" to 42,
+         "customer_name" to "Alice",
+      ),
+      snakeMikrom,
+   )
+   assertEquals(Invoice(42, "Alice"), invoice)
+
+   // Test @Column overrides naming strategy
+   val overridden = OverriddenEntity.rowMapper().mapRow(
+      Row.of(
+         "custom_col" to "hello",
+         "other_field" to 99,
+      ),
+      snakeMikrom,
+   )
+   assertEquals(OverriddenEntity("hello", 99), overridden)
+
+   // Test AS_IS preserves parameter names
+   val asIsMikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY, NamingStrategy.AS_IS)
+   val entity = AsIsEntity.rowMapper().mapRow(
+      Row.of(
+         "firstName" to "Bob",
+      ),
+      asIsMikrom,
+   )
+   assertEquals(AsIsEntity("Bob"), entity)
+
+   return "OK"
+}
+
+@RowMapped
+data class Invoice(
+   val invoiceId: Int,
+   val customerName: String,
+)
+
+@RowMapped
+data class OverriddenEntity(
+   @Column("custom_col") val name: String,
+   val otherField: Int,
+)
+
+@RowMapped
+data class AsIsEntity(
+   val firstName: String,
+)

--- a/mikrom-compiler-plugin/testData/box/NullableValueClass.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/NullableValueClass.fir.ir.txt
@@ -81,7 +81,10 @@ FILE fqName:<root> fileName:/NullableValueClass.kt
                 TYPE_ARG T: kotlin.String
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Contact.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
                 ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Contact.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
-                ARG column: CONST String type=kotlin.String value="name"
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Contact.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="name"
                 ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
           VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:T of io.github.kantis.mikrom.Row.getOrNull? [val]
             BLOCK type=T of io.github.kantis.mikrom.Row.getOrNull? origin=null
@@ -89,7 +92,10 @@ FILE fqName:<root> fileName:/NullableValueClass.kt
                 TYPE_ARG T: <root>.Email
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Contact.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
                 ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Contact.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
-                ARG column: CONST String type=kotlin.String value="email"
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Contact.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="email"
                 ARG clazz: CLASS_REFERENCE 'CLASS CLASS name:Email modality:FINAL visibility:public [value] superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Email>
           RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.Contact declared in <root>.Contact.$RowMapper'
             CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, email: <root>.Email?) declared in <root>.Contact' type=<root>.Contact origin=null
@@ -287,7 +293,7 @@ FILE fqName:<root> fileName:/NullableValueClass.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions, namingStrategy: io.github.kantis.mikrom.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>

--- a/mikrom-compiler-plugin/testData/box/Person.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/Person.fir.ir.txt
@@ -92,7 +92,10 @@ FILE fqName:<root> fileName:/Person.kt
                 TYPE_ARG T: kotlin.String
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Person.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
                 ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Person.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
-                ARG column: CONST String type=kotlin.String value="name"
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Person.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="name"
                 ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
           VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:T of io.github.kantis.mikrom.Row.getOrNull? [val]
             BLOCK type=T of io.github.kantis.mikrom.Row.getOrNull? origin=null
@@ -100,7 +103,10 @@ FILE fqName:<root> fileName:/Person.kt
                 TYPE_ARG T: kotlin.String
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Person.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
                 ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Person.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
-                ARG column: CONST String type=kotlin.String value="nickname"
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Person.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="nickname"
                 ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
           VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:T of io.github.kantis.mikrom.Row.get [val]
             BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
@@ -108,7 +114,10 @@ FILE fqName:<root> fileName:/Person.kt
                 TYPE_ARG T: kotlin.Int
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.Person.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
                 ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Person.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
-                ARG column: CONST String type=kotlin.String value="age"
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.Person.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="age"
                 ARG clazz: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.Int>
           RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.Person declared in <root>.Person.$RowMapper'
             CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, nickname: kotlin.String?, age: kotlin.Int) declared in <root>.Person' type=<root>.Person origin=null
@@ -277,7 +286,7 @@ FILE fqName:<root> fileName:/Person.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions, namingStrategy: io.github.kantis.mikrom.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>

--- a/mikrom-compiler-plugin/testData/box/ValueClass.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/ValueClass.fir.ir.txt
@@ -217,7 +217,10 @@ FILE fqName:<root> fileName:/ValueClass.kt
                 TYPE_ARG T: <root>.UserId
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.UserWithValueClass.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
                 ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.UserWithValueClass.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
-                ARG column: CONST String type=kotlin.String value="id"
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.UserWithValueClass.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="id"
                 ARG clazz: CLASS_REFERENCE 'CLASS CLASS name:UserId modality:FINAL visibility:public [value] superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.UserId>
           VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:T of io.github.kantis.mikrom.Row.get [val]
             BLOCK type=T of io.github.kantis.mikrom.Row.get origin=null
@@ -225,7 +228,10 @@ FILE fqName:<root> fileName:/ValueClass.kt
                 TYPE_ARG T: <root>.Age
                 ARG <this>: GET_VAR 'row: io.github.kantis.mikrom.Row declared in <root>.UserWithValueClass.$RowMapper.mapRow' type=io.github.kantis.mikrom.Row origin=null
                 ARG mikrom: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.UserWithValueClass.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
-                ARG column: CONST String type=kotlin.String value="age"
+                ARG column: CALL 'public abstract fun toColumnName (parameterName: kotlin.String): kotlin.String declared in io.github.kantis.mikrom.NamingStrategy' type=kotlin.String origin=null
+                  ARG <this>: CALL 'public final fun <get-namingStrategy> (): io.github.kantis.mikrom.NamingStrategy declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.NamingStrategy origin=null
+                    ARG <this>: GET_VAR 'mikrom: io.github.kantis.mikrom.Mikrom declared in <root>.UserWithValueClass.$RowMapper.mapRow' type=io.github.kantis.mikrom.Mikrom origin=null
+                  ARG parameterName: CONST String type=kotlin.String value="age"
                 ARG clazz: CLASS_REFERENCE 'CLASS CLASS name:Age modality:FINAL visibility:public [value] superTypes:[kotlin.Any]' type=kotlin.reflect.KClass<<root>.Age>
           RETURN type=kotlin.Nothing from='public final fun mapRow (row: io.github.kantis.mikrom.Row, mikrom: io.github.kantis.mikrom.Mikrom): <root>.UserWithValueClass declared in <root>.UserWithValueClass.$RowMapper'
             CONSTRUCTOR_CALL 'public constructor <init> (id: <root>.UserId, age: <root>.Age) declared in <root>.UserWithValueClass' type=<root>.UserWithValueClass origin=null
@@ -346,7 +352,7 @@ FILE fqName:<root> fileName:/ValueClass.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.TypeConversions, namingStrategy: io.github.kantis.mikrom.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>

--- a/mikrom/mikrom-core/api/mikrom-core.api
+++ b/mikrom/mikrom-core/api/mikrom-core.api
@@ -9,9 +9,10 @@ public final class io/github/kantis/mikrom/DefaultConversions_jvmKt {
 
 public final class io/github/kantis/mikrom/Mikrom {
 	public static final field Companion Lio/github/kantis/mikrom/Mikrom$Companion;
-	public fun <init> (Ljava/util/Map;Lio/github/kantis/mikrom/TypeConversions;)V
-	public synthetic fun <init> (Ljava/util/Map;Lio/github/kantis/mikrom/TypeConversions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;Lio/github/kantis/mikrom/TypeConversions;Lio/github/kantis/mikrom/NamingStrategy;)V
+	public synthetic fun <init> (Ljava/util/Map;Lio/github/kantis/mikrom/TypeConversions;Lio/github/kantis/mikrom/NamingStrategy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConversions ()Lio/github/kantis/mikrom/TypeConversions;
+	public final fun getNamingStrategy ()Lio/github/kantis/mikrom/NamingStrategy;
 	public final fun getRowMappers ()Ljava/util/Map;
 }
 
@@ -23,10 +24,23 @@ public final class io/github/kantis/mikrom/MikromBuilder {
 	public fun <init> ()V
 	public final fun build ()Lio/github/kantis/mikrom/Mikrom;
 	public final fun getConversionsBuilder ()Lio/github/kantis/mikrom/TypeConversions$Builder;
+	public final fun getNamingStrategy ()Lio/github/kantis/mikrom/NamingStrategy;
 	public final fun getRowMappers ()Ljava/util/Map;
+	public final fun setNamingStrategy (Lio/github/kantis/mikrom/NamingStrategy;)V
 }
 
 public abstract interface annotation class io/github/kantis/mikrom/MikromInternal : java/lang/annotation/Annotation {
+}
+
+public abstract interface class io/github/kantis/mikrom/NamingStrategy {
+	public static final field Companion Lio/github/kantis/mikrom/NamingStrategy$Companion;
+	public abstract fun toColumnName (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class io/github/kantis/mikrom/NamingStrategy$Companion {
+	public final fun getAS_IS ()Lio/github/kantis/mikrom/NamingStrategy;
+	public final fun getSNAKE_CASE ()Lio/github/kantis/mikrom/NamingStrategy;
+	public final fun getUPPER_SNAKE_CASE ()Lio/github/kantis/mikrom/NamingStrategy;
 }
 
 public final class io/github/kantis/mikrom/PrimitivesKt {

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/Mikrom.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/Mikrom.kt
@@ -6,6 +6,7 @@ import kotlin.reflect.KClass
 public class Mikrom(
    public val rowMappers: MutableMap<KClass<*>, RowMapper<*>>,
    public val conversions: TypeConversions = defaultConversions(),
+   public val namingStrategy: NamingStrategy = NamingStrategy.SNAKE_CASE,
 ) {
    @Suppress("UNCHECKED_CAST")
    public inline fun <reified T : Any> resolveRowMapper(): RowMapper<T> =

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/MikromBuilder.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/MikromBuilder.kt
@@ -4,6 +4,7 @@ import kotlin.reflect.KClass
 
 public class MikromBuilder {
    public val rowMappers: MutableMap<KClass<*>, RowMapper<*>> = mutableMapOf()
+   public var namingStrategy: NamingStrategy = NamingStrategy.SNAKE_CASE
 
    @PublishedApi
    internal val conversionsBuilder: TypeConversions.Builder = TypeConversions.Builder()
@@ -20,5 +21,5 @@ public class MikromBuilder {
       conversionsBuilder.register(conversion)
    }
 
-   public fun build(): Mikrom = Mikrom(rowMappers, defaultConversions() + conversionsBuilder.build())
+   public fun build(): Mikrom = Mikrom(rowMappers, defaultConversions() + conversionsBuilder.build(), namingStrategy)
 }

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/NamingStrategy.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/NamingStrategy.kt
@@ -1,0 +1,26 @@
+package io.github.kantis.mikrom
+
+public fun interface NamingStrategy {
+   public fun toColumnName(parameterName: String): String
+
+   public companion object {
+      public val AS_IS: NamingStrategy = NamingStrategy { it }
+
+      public val SNAKE_CASE: NamingStrategy = NamingStrategy { name ->
+         buildString {
+            for (char in name) {
+               if (char.isUpperCase()) {
+                  if (isNotEmpty()) append('_')
+                  append(char.lowercase())
+               } else {
+                  append(char)
+               }
+            }
+         }
+      }
+
+      public val UPPER_SNAKE_CASE: NamingStrategy = NamingStrategy { name ->
+         SNAKE_CASE.toColumnName(name).uppercase()
+      }
+   }
+}

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/NamingStrategy.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/NamingStrategy.kt
@@ -1,11 +1,36 @@
 package io.github.kantis.mikrom
 
+/**
+ * Transforms Kotlin parameter names into database column names.
+ *
+ * Configure on a [Mikrom] instance to automatically map constructor parameter
+ * names to column names. An explicit [@Column][io.github.kantis.mikrom.generator.Column]
+ * annotation always takes precedence over the naming strategy.
+ */
 public fun interface NamingStrategy {
    public fun toColumnName(parameterName: String): String
 
    public companion object {
+      /**
+       * Identity strategy — returns the parameter name unchanged.
+       *
+       * ```
+       * "invoiceId"    -> "invoiceId"
+       * "customerName" -> "customerName"
+       * ```
+       */
       public val AS_IS: NamingStrategy = NamingStrategy { it }
 
+      /**
+       * Converts camelCase parameter names to lower snake_case column names.
+       * This is the default strategy.
+       *
+       * ```
+       * "invoiceId"    -> "invoice_id"
+       * "customerName" -> "customer_name"
+       * "age"          -> "age"
+       * ```
+       */
       public val SNAKE_CASE: NamingStrategy = NamingStrategy { name ->
          buildString {
             for (char in name) {
@@ -19,6 +44,15 @@ public fun interface NamingStrategy {
          }
       }
 
+      /**
+       * Converts camelCase parameter names to UPPER_SNAKE_CASE column names.
+       *
+       * ```
+       * "invoiceId"    -> "INVOICE_ID"
+       * "customerName" -> "CUSTOMER_NAME"
+       * "age"          -> "AGE"
+       * ```
+       */
       public val UPPER_SNAKE_CASE: NamingStrategy = NamingStrategy { name ->
          SNAKE_CASE.toColumnName(name).uppercase()
       }

--- a/mikrom/mikrom-core/src/commonTest/kotlin/io/github/kantis/mikrom/NamingStrategyTest.kt
+++ b/mikrom/mikrom-core/src/commonTest/kotlin/io/github/kantis/mikrom/NamingStrategyTest.kt
@@ -1,0 +1,26 @@
+package io.github.kantis.mikrom
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class NamingStrategyTest : FunSpec({
+   test("AS_IS returns parameter name unchanged") {
+      NamingStrategy.AS_IS.toColumnName("invoiceId") shouldBe "invoiceId"
+      NamingStrategy.AS_IS.toColumnName("name") shouldBe "name"
+      NamingStrategy.AS_IS.toColumnName("already_snake") shouldBe "already_snake"
+   }
+
+   test("SNAKE_CASE converts camelCase to snake_case") {
+      NamingStrategy.SNAKE_CASE.toColumnName("invoiceId") shouldBe "invoice_id"
+      NamingStrategy.SNAKE_CASE.toColumnName("customerName") shouldBe "customer_name"
+      NamingStrategy.SNAKE_CASE.toColumnName("name") shouldBe "name"
+      NamingStrategy.SNAKE_CASE.toColumnName("htmlParser") shouldBe "html_parser"
+      NamingStrategy.SNAKE_CASE.toColumnName("myURLParser") shouldBe "my_u_r_l_parser"
+   }
+
+   test("UPPER_SNAKE_CASE converts camelCase to UPPER_SNAKE_CASE") {
+      NamingStrategy.UPPER_SNAKE_CASE.toColumnName("invoiceId") shouldBe "INVOICE_ID"
+      NamingStrategy.UPPER_SNAKE_CASE.toColumnName("name") shouldBe "NAME"
+      NamingStrategy.UPPER_SNAKE_CASE.toColumnName("customerName") shouldBe "CUSTOMER_NAME"
+   }
+})


### PR DESCRIPTION
## Summary
- Introduces a `NamingStrategy` fun interface configurable on the `Mikrom` instance that automatically transforms Kotlin parameter names to database column names
- Built-in strategies: `AS_IS` (identity), `SNAKE_CASE` (default), `UPPER_SNAKE_CASE`
- Precedence: `@Column` annotation > `namingStrategy.toColumnName()` > identity
- Compiler plugin now emits runtime `namingStrategy.toColumnName()` calls for non-`@Column` parameters instead of compile-time string literals

## Test plan
- [x] Unit tests for all three naming strategies (`NamingStrategyTest`)
- [x] Box test verifying SNAKE_CASE mapping, `@Column` override, and AS_IS identity
- [x] All existing box tests pass with regenerated IR dumps
- [x] Full build passes including API check, ktlint, and all module tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)