### PR TITLE
Add Timestamp -> LocalDateTime default conversion

### DIFF
--- a/mikrom/mikrom-core/src/jvmMain/kotlin/io/github/kantis/mikrom/DefaultConversions.jvm.kt
+++ b/mikrom/mikrom-core/src/jvmMain/kotlin/io/github/kantis/mikrom/DefaultConversions.jvm.kt
@@ -2,8 +2,10 @@ package io.github.kantis.mikrom
 
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.LocalDateTime
 
 public actual fun platformDefaultConversions(): TypeConversions =
    TypeConversions.Builder().apply {
       register<Timestamp, Instant> { it.toInstant() }
+      register<Timestamp, LocalDateTime> { it.toLocalDateTime() }
    }.build()

--- a/mikrom/mikrom-core/src/jvmTest/kotlin/io/github/kantis/mikrom/DefaultConversionsJvmTest.kt
+++ b/mikrom/mikrom-core/src/jvmTest/kotlin/io/github/kantis/mikrom/DefaultConversionsJvmTest.kt
@@ -1,0 +1,26 @@
+package io.github.kantis.mikrom
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.LocalDateTime
+
+class DefaultConversionsJvmTest : FunSpec({
+   val now = Instant.parse("2023-12-25T15:30:45.001Z")
+   val timestamp = Timestamp.from(now)
+   val mikrom = Mikrom(mutableMapOf())
+   val row = Row.of("ts" to timestamp)
+
+   test("Timestamp is converted to Instant") {
+      with(mikrom) {
+         row.get<Instant>("ts") shouldBe now
+      }
+   }
+
+   test("Timestamp is converted to LocalDateTime") {
+      with(mikrom) {
+         row.get<LocalDateTime>("ts") shouldBe timestamp.toLocalDateTime()
+      }
+   }
+})


### PR DESCRIPTION
## Summary
- Add `Timestamp -> LocalDateTime` default conversion using `Timestamp.toLocalDateTime()`
- Add tests for both `Timestamp -> Instant` and `Timestamp -> LocalDateTime` JVM default conversions

## Test plan
- [x] `./gradlew build` passes (all modules)
- [x] New tests in `DefaultConversionsJvmTest` verify both conversions

🤖 Generated with [Claude Code](https://claude.com/claude-code)