### PR TITLE
Add ParameterMapper interface

### DIFF
--- a/example/src/jvmTest/kotlin/io/github/kantis/mikrom/example/BookTest.kt
+++ b/example/src/jvmTest/kotlin/io/github/kantis/mikrom/example/BookTest.kt
@@ -8,10 +8,10 @@ import io.kotest.matchers.shouldBe
 
 class BookTest : FunSpec(
    {
-      val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+      val mikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY)
 
       test("rowMapper() companion accessor returns generated mapper") {
-         val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+         val mikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY)
          val book: Book = Book.rowMapper().mapRow(
             Row.of(
                "author" to "JRR Tolkien",

--- a/mikrom-compiler-plugin/testData/box/ColumnAnnotation.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/ColumnAnnotation.fir.ir.txt
@@ -275,7 +275,7 @@ FILE fqName:<root> fileName:/ColumnAnnotation.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, parameterMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.ParameterMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>

--- a/mikrom-compiler-plugin/testData/box/ColumnAnnotation.kt
+++ b/mikrom-compiler-plugin/testData/box/ColumnAnnotation.kt
@@ -9,7 +9,7 @@ import io.github.kantis.mikrom.generator.RowMapped
 import kotlin.test.*
 
 fun box(): String {
-   val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+   val mikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY)
    val user = DbUser.rowMapper().mapRow(
       Row.of(
          "user_name" to "Alice",

--- a/mikrom-compiler-plugin/testData/box/NamingStrategy.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/NamingStrategy.fir.ir.txt
@@ -586,7 +586,7 @@ FILE fqName:<root> fileName:/NamingStrategy.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:snakeMikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, parameterMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.ParameterMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>
@@ -641,7 +641,7 @@ FILE fqName:<root> fileName:/NamingStrategy.kt
           ARG otherField: CONST Int type=kotlin.Int value=99
         ARG actual: GET_VAR 'val overridden: <root>.OverriddenEntity declared in <root>.box' type=<root>.OverriddenEntity origin=null
       VAR name:asIsMikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, parameterMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.ParameterMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>

--- a/mikrom-compiler-plugin/testData/box/NamingStrategy.kt
+++ b/mikrom-compiler-plugin/testData/box/NamingStrategy.kt
@@ -11,7 +11,7 @@ import kotlin.test.*
 
 fun box(): String {
    // Test SNAKE_CASE (default)
-   val snakeMikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+   val snakeMikrom = Mikrom(mutableMapOf(), conversions =TypeConversions.EMPTY)
    val invoice = Invoice.rowMapper().mapRow(
       Row.of(
          "invoice_id" to 42,
@@ -32,7 +32,7 @@ fun box(): String {
    assertEquals(OverriddenEntity("hello", 99), overridden)
 
    // Test AS_IS preserves parameter names
-   val asIsMikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY, NamingStrategy.AS_IS)
+   val asIsMikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY, namingStrategy = NamingStrategy.AS_IS)
    val entity = AsIsEntity.rowMapper().mapRow(
       Row.of(
          "firstName" to "Bob",

--- a/mikrom-compiler-plugin/testData/box/NullableValueClass.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/NullableValueClass.fir.ir.txt
@@ -293,7 +293,7 @@ FILE fqName:<root> fileName:/NullableValueClass.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, parameterMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.ParameterMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>

--- a/mikrom-compiler-plugin/testData/box/NullableValueClass.kt
+++ b/mikrom-compiler-plugin/testData/box/NullableValueClass.kt
@@ -17,7 +17,7 @@ data class Contact(
 )
 
 fun box(): String {
-   val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+   val mikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY)
 
    // Test with non-null value
    val contact1 = Contact.rowMapper().mapRow(

--- a/mikrom-compiler-plugin/testData/box/Person.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/Person.fir.ir.txt
@@ -286,7 +286,7 @@ FILE fqName:<root> fileName:/Person.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, parameterMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.ParameterMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>

--- a/mikrom-compiler-plugin/testData/box/Person.kt
+++ b/mikrom-compiler-plugin/testData/box/Person.kt
@@ -8,7 +8,7 @@ import io.github.kantis.mikrom.generator.RowMapped
 import kotlin.test.*
 
 fun box(): String {
-   val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+   val mikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY)
    val person = Person.rowMapper().mapRow(
       Row.of(
          "name" to "Brian",

--- a/mikrom-compiler-plugin/testData/box/ValueClass.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/ValueClass.fir.ir.txt
@@ -352,7 +352,7 @@ FILE fqName:<root> fileName:/ValueClass.kt
   FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       VAR name:mikrom type:io.github.kantis.mikrom.Mikrom [val]
-        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
+        CONSTRUCTOR_CALL 'public constructor <init> (rowMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>>, parameterMappers: kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.ParameterMapper<*>>, conversions: io.github.kantis.mikrom.convert.TypeConversions, namingStrategy: io.github.kantis.mikrom.generator.NamingStrategy) declared in io.github.kantis.mikrom.Mikrom' type=io.github.kantis.mikrom.Mikrom origin=null
           ARG rowMappers: CALL 'public final fun mutableMapOf <K, V> (): kotlin.collections.MutableMap<K of kotlin.collections.mutableMapOf, V of kotlin.collections.mutableMapOf> declared in kotlin.collections' type=kotlin.collections.MutableMap<kotlin.reflect.KClass<*>, io.github.kantis.mikrom.RowMapper<*>> origin=null
             TYPE_ARG K: kotlin.reflect.KClass<*>
             TYPE_ARG V: io.github.kantis.mikrom.RowMapper<*>

--- a/mikrom-compiler-plugin/testData/box/ValueClass.kt
+++ b/mikrom-compiler-plugin/testData/box/ValueClass.kt
@@ -20,7 +20,7 @@ data class UserWithValueClass(
 )
 
 fun box(): String {
-   val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+   val mikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY)
    val user = UserWithValueClass.rowMapper().mapRow(
       Row.of(
          "id" to "user-123",

--- a/mikrom/mikrom-core/api/mikrom-core.api
+++ b/mikrom/mikrom-core/api/mikrom-core.api
@@ -1,9 +1,10 @@
 public final class io/github/kantis/mikrom/Mikrom {
 	public static final field Companion Lio/github/kantis/mikrom/Mikrom$Companion;
-	public fun <init> (Ljava/util/Map;Lio/github/kantis/mikrom/convert/TypeConversions;Lio/github/kantis/mikrom/generator/NamingStrategy;)V
-	public synthetic fun <init> (Ljava/util/Map;Lio/github/kantis/mikrom/convert/TypeConversions;Lio/github/kantis/mikrom/generator/NamingStrategy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;Lio/github/kantis/mikrom/convert/TypeConversions;Lio/github/kantis/mikrom/generator/NamingStrategy;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Lio/github/kantis/mikrom/convert/TypeConversions;Lio/github/kantis/mikrom/generator/NamingStrategy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getConversions ()Lio/github/kantis/mikrom/convert/TypeConversions;
 	public final fun getNamingStrategy ()Lio/github/kantis/mikrom/generator/NamingStrategy;
+	public final fun getParameterMappers ()Ljava/util/Map;
 	public final fun getRowMappers ()Ljava/util/Map;
 }
 
@@ -16,8 +17,17 @@ public final class io/github/kantis/mikrom/MikromBuilder {
 	public final fun build ()Lio/github/kantis/mikrom/Mikrom;
 	public final fun getConversionsBuilder ()Lio/github/kantis/mikrom/convert/TypeConversions$Builder;
 	public final fun getNamingStrategy ()Lio/github/kantis/mikrom/generator/NamingStrategy;
+	public final fun getParameterMappers ()Ljava/util/Map;
 	public final fun getRowMappers ()Ljava/util/Map;
 	public final fun setNamingStrategy (Lio/github/kantis/mikrom/generator/NamingStrategy;)V
+}
+
+public final class io/github/kantis/mikrom/MikromBuilder$sam$i$io_github_kantis_mikrom_ParameterMapper$0 : io/github/kantis/mikrom/ParameterMapper, kotlin/jvm/internal/FunctionAdapter {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun equals (Ljava/lang/Object;)Z
+	public final fun getFunctionDelegate ()Lkotlin/Function;
+	public final fun hashCode ()I
+	public final synthetic fun mapParameters (Ljava/lang/Object;)Ljava/util/Map;
 }
 
 public abstract interface annotation class io/github/kantis/mikrom/MikromInternal : java/lang/annotation/Annotation {
@@ -26,6 +36,10 @@ public abstract interface annotation class io/github/kantis/mikrom/MikromInterna
 public final class io/github/kantis/mikrom/NamedParameterParserKt {
 	public static final fun parseNamedParameters (Ljava/lang/String;)Lio/github/kantis/mikrom/ParsedQuery;
 	public static final fun resolveParams (Lio/github/kantis/mikrom/ParsedQuery;Ljava/util/Map;)Ljava/util/List;
+}
+
+public abstract interface class io/github/kantis/mikrom/ParameterMapper {
+	public abstract fun mapParameters (Ljava/lang/Object;)Ljava/util/Map;
 }
 
 public final class io/github/kantis/mikrom/ParsedQuery {

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/Mikrom.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/Mikrom.kt
@@ -8,6 +8,7 @@ import kotlin.reflect.KClass
 
 public class Mikrom(
    public val rowMappers: MutableMap<KClass<*>, RowMapper<*>>,
+   public val parameterMappers: MutableMap<KClass<*>, ParameterMapper<*>> = mutableMapOf(),
    public val conversions: TypeConversions = defaultConversions(),
    public val namingStrategy: NamingStrategy = NamingStrategy.SNAKE_CASE,
 ) {
@@ -16,6 +17,11 @@ public class Mikrom(
       rowMappers[T::class] as? RowMapper<T>
          ?: T::class.compiledRowMapper()
          ?: error("No RowMapper found for type ${T::class}. Please register a RowMapper or ensure it is compiled with the Mikrom plugin.")
+
+   @Suppress("UNCHECKED_CAST")
+   public inline fun <reified T : Any> resolveParameterMapper(): ParameterMapper<T> =
+      parameterMappers[T::class] as? ParameterMapper<T>
+         ?: error("No ParameterMapper found for type ${T::class}. Please register a ParameterMapper.")
 
    public companion object {
       public operator fun invoke(builder: MikromBuilder.() -> Unit): Mikrom = MikromBuilder().apply(builder).build()

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/MikromBuilder.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/MikromBuilder.kt
@@ -7,6 +7,7 @@ import kotlin.reflect.KClass
 
 public class MikromBuilder {
    public val rowMappers: MutableMap<KClass<*>, RowMapper<*>> = mutableMapOf()
+   public val parameterMappers: MutableMap<KClass<*>, ParameterMapper<*>> = mutableMapOf()
    public var namingStrategy: NamingStrategy = NamingStrategy.SNAKE_CASE
 
    @PublishedApi
@@ -20,9 +21,17 @@ public class MikromBuilder {
       rowMappers[T::class] = RowMapper { row, mikrom -> mapper(mikrom, row) }
    }
 
+   public inline fun <reified T> registerParameterMapper(mapper: ParameterMapper<T>) {
+      parameterMappers[T::class] = mapper
+   }
+
+   public inline fun <reified T> registerParameterMapper(noinline mapper: (T) -> Map<String, Any?>) {
+      parameterMappers[T::class] = ParameterMapper(mapper)
+   }
+
    public inline fun <reified S : Any, reified T : Any> registerConversion(noinline conversion: (S) -> T) {
       conversionsBuilder.register(conversion)
    }
 
-   public fun build(): Mikrom = Mikrom(rowMappers, defaultConversions() + conversionsBuilder.build(), namingStrategy)
+   public fun build(): Mikrom = Mikrom(rowMappers, parameterMappers, defaultConversions() + conversionsBuilder.build(), namingStrategy)
 }

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/ParameterMapper.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/ParameterMapper.kt
@@ -1,0 +1,5 @@
+package io.github.kantis.mikrom
+
+public fun interface ParameterMapper<in T> {
+   public fun mapParameters(value: T): Map<String, Any?>
+}

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/queries.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/queries.kt
@@ -48,13 +48,21 @@ public fun Mikrom.execute(
    params.forEach { transaction.executeInTransaction(query, it) }
 }
 
+@Suppress("UNCHECKED_CAST")
 context(transaction: Transaction)
 public fun <T : Any> Mikrom.execute(
    query: Query,
    vararg params: T,
 ) {
    params.forEach {
-      if (it is List<*>) transaction.executeInTransaction(query, it) else transaction.executeInTransaction(query, listOf(it))
+      val mapper = parameterMappers[it::class] as? ParameterMapper<T>
+      if (mapper != null) {
+         execute(query, mapper.mapParameters(it))
+      } else if (it is List<*>) {
+         transaction.executeInTransaction(query, it)
+      } else {
+         transaction.executeInTransaction(query, listOf(it))
+      }
    }
 }
 

--- a/mikrom/mikrom-core/src/jvmTest/kotlin/io/github/kantis/mikrom/ValueClassSupportTest.kt
+++ b/mikrom/mikrom-core/src/jvmTest/kotlin/io/github/kantis/mikrom/ValueClassSupportTest.kt
@@ -38,7 +38,7 @@ class ValueClassSupportTest : FunSpec({
    }
 
    test("Row.get supports value classes") {
-      val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+      val mikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY)
       val row = Row.of("id" to "user-123")
       with(mikrom) {
          row.get<UserId>("id") shouldBe UserId("user-123")
@@ -46,7 +46,7 @@ class ValueClassSupportTest : FunSpec({
    }
 
    test("Row.getOrNull supports value classes with non-null value") {
-      val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+      val mikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY)
       val row = Row.of("id" to "user-123")
       with(mikrom) {
          row.getOrNull<UserId>("id") shouldBe UserId("user-123")
@@ -54,7 +54,7 @@ class ValueClassSupportTest : FunSpec({
    }
 
    test("Row.getOrNull supports value classes with null value") {
-      val mikrom = Mikrom(mutableMapOf(), TypeConversions.EMPTY)
+      val mikrom = Mikrom(mutableMapOf(), conversions = TypeConversions.EMPTY)
       val row = Row.of("id" to null)
       with(mikrom) {
          row.getOrNull<UserId>("id") shouldBe null

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/ParameterMapperJdbcTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/ParameterMapperJdbcTest.kt
@@ -1,0 +1,118 @@
+package io.github.kantis.mikrom.jdbc
+
+import io.github.kantis.mikrom.Mikrom
+import io.github.kantis.mikrom.ParameterMapper
+import io.github.kantis.mikrom.Query
+import io.github.kantis.mikrom.execute
+import io.github.kantis.mikrom.get
+import io.github.kantis.mikrom.jdbc.h2.prepareH2Database
+import io.github.kantis.mikrom.queryFor
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+private data class Employee(val name: String, val age: Int)
+
+class ParameterMapperJdbcTest : FunSpec(
+   {
+      test("execute with parameter mapper") {
+         val mikrom =
+            Mikrom {
+               registerRowMapper { row ->
+                  Employee(row.get("name"), row.get("age"))
+               }
+               registerParameterMapper<Employee> { employee ->
+                  mapOf("name" to employee.name, "age" to employee.age)
+               }
+            }
+
+         val dataSource = prepareH2Database(
+            """
+               CREATE TABLE employees (
+                  name VARCHAR(255),
+                  age INT
+               )
+            """.trimIndent(),
+         )
+
+         dataSource.transaction {
+            mikrom.execute(
+               Query("INSERT INTO employees (name, age) VALUES (:name, :age)"),
+               Employee("Alice", 30),
+            )
+
+            mikrom.queryFor<Employee>(
+               Query("SELECT * FROM employees"),
+            ) shouldBe listOf(Employee("Alice", 30))
+         }
+      }
+
+      test("batch execute with parameter mapper") {
+         val mikrom =
+            Mikrom {
+               registerParameterMapper<Employee>(
+                  ParameterMapper { employee ->
+                     mapOf("name" to employee.name, "age" to employee.age)
+                  },
+               )
+            }
+
+         val dataSource = prepareH2Database(
+            """
+               CREATE TABLE staff (
+                  name VARCHAR(255),
+                  age INT
+               )
+            """.trimIndent(),
+         )
+
+         dataSource.transaction {
+            mikrom.execute(
+               Query("INSERT INTO staff (name, age) VALUES (:name, :age)"),
+               Employee("Alice", 30),
+               Employee("Bob", 25),
+            )
+
+            mikrom.queryFor<Int>(
+               Query("SELECT COUNT(*) FROM staff"),
+            ) shouldBe listOf(2)
+         }
+      }
+
+      test("queryFor with resolveParameterMapper") {
+         val mikrom =
+            Mikrom {
+               registerRowMapper { row ->
+                  Employee(row.get("name"), row.get("age"))
+               }
+               registerParameterMapper<Employee> { employee ->
+                  mapOf("name" to employee.name, "age" to employee.age)
+               }
+            }
+
+         val dataSource = prepareH2Database(
+            """
+               CREATE TABLE workers (
+                  name VARCHAR(255),
+                  age INT
+               )
+            """.trimIndent(),
+         )
+
+         dataSource.transaction {
+            mikrom.execute(
+               Query("INSERT INTO workers (name, age) VALUES (:name, :age)"),
+               Employee("Alice", 30),
+               Employee("Bob", 25),
+            )
+
+            val filter = Employee("Alice", 30)
+            val params = mikrom.resolveParameterMapper<Employee>().mapParameters(filter)
+
+            mikrom.queryFor<Employee>(
+               Query("SELECT * FROM workers WHERE name = :name"),
+               params,
+            ) shouldBe listOf(Employee("Alice", 30))
+         }
+      }
+   },
+)


### PR DESCRIPTION
## Summary
- Adds `ParameterMapper<in T>` fun interface for mapping domain objects to named parameter maps, mirroring the `RowMapper<T>` pattern
- Adds `registerParameterMapper` overloads (interface + lambda) to `MikromBuilder`
- Adds `resolveParameterMapper<T>()` to `Mikrom` for manual resolution
- The catch-all `execute(Query, vararg T)` automatically uses registered parameter mappers

## Test plan
- [x] `execute` with a registered parameter mapper inserts correctly
- [x] Batch `execute` with multiple domain objects via parameter mapper
- [x] `resolveParameterMapper` + `queryFor` with the resulting map
- [x] `./gradlew build` passes all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)