### PR TITLE
Allow null values in named parameter maps

### DIFF
--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/queries.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/queries.kt
@@ -24,7 +24,7 @@ public inline fun <reified T> Mikrom.queryFor(
 context(transaction: Transaction)
 public inline fun <reified T : Any> Mikrom.queryFor(
    query: Query,
-   params: List<Any>,
+   params: List<Any?>,
 ): List<T> {
    if (T::class in nonMappedPrimitives) {
       return transaction.query(query, params).map { it.singleValue() as T }
@@ -36,7 +36,7 @@ public inline fun <reified T : Any> Mikrom.queryFor(
 context(transaction: Transaction)
 public fun Mikrom.execute(
    query: Query,
-   params: List<Any>,
+   params: List<Any?>,
 ) {
    transaction.executeInTransaction(query, params)
 }
@@ -44,7 +44,7 @@ public fun Mikrom.execute(
 context(transaction: Transaction)
 public fun Mikrom.execute(
    query: Query,
-   vararg params: List<Any>,
+   vararg params: List<Any?>,
 ) {
    params.forEach { transaction.executeInTransaction(query, it) }
 }
@@ -79,7 +79,7 @@ public inline fun <reified T : Any> Mikrom.queryFor(
    params: Map<String, Any?>,
 ): List<T> {
    val parsed = parseNamedParameters(query.value)
-   return queryFor(Query(parsed.sql), parsed.resolveParams(params).filterNotNull())
+   return queryFor(Query(parsed.sql), parsed.resolveParams(params))
 }
 
 context(transaction: Transaction)
@@ -88,7 +88,7 @@ public fun Mikrom.execute(
    params: Map<String, Any?>,
 ) {
    val parsed = parseNamedParameters(query.value)
-   execute(Query(parsed.sql), parsed.resolveParams(params).filterNotNull())
+   execute(Query(parsed.sql), parsed.resolveParams(params))
 }
 
 context(transaction: Transaction)
@@ -99,6 +99,6 @@ public fun Mikrom.execute(
    val parsed = parseNamedParameters(query.value)
    val parsedQuery = Query(parsed.sql)
    paramMaps.forEach {
-      execute(parsedQuery, parsed.resolveParams(it).filterNotNull())
+      execute(parsedQuery, parsed.resolveParams(it))
    }
 }

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/queryFor.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/queryFor.kt
@@ -26,7 +26,7 @@ public suspend inline fun <reified T> Mikrom.queryFor(
 context(transaction: SuspendingTransaction)
 public suspend inline fun <reified T : Any> Mikrom.queryFor(
    query: Query,
-   params: List<Any>,
+   params: List<Any?>,
 ): Flow<T> {
    if (T::class in nonMappedPrimitives) {
       return transaction.query(query, params).map { it.singleValue() as T }
@@ -41,5 +41,5 @@ public suspend inline fun <reified T : Any> Mikrom.queryFor(
    params: Map<String, Any?>,
 ): Flow<T> {
    val parsed = parseNamedParameters(query.value)
-   return queryFor(Query(parsed.sql), parsed.resolveParams(params).filterNotNull())
+   return queryFor(Query(parsed.sql), parsed.resolveParams(params))
 }

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/suspendQueries.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/suspendQueries.kt
@@ -11,7 +11,7 @@ import kotlin.collections.emptyList
 context(transaction: SuspendingTransaction)
 public suspend inline fun Mikrom.execute(
    query: Query,
-   params: List<Any>,
+   params: List<Any?>,
 ) {
    transaction.executeInTransaction(query, params)
 }
@@ -50,5 +50,5 @@ public suspend fun Mikrom.execute(
    params: Map<String, Any?>,
 ) {
    val parsed = parseNamedParameters(query.value)
-   execute(Query(parsed.sql), parsed.resolveParams(params).filterNotNull())
+   execute(Query(parsed.sql), parsed.resolveParams(params))
 }

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/NamedParamsJdbcTest.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/NamedParamsJdbcTest.kt
@@ -68,6 +68,100 @@ class NamedParamsJdbcTest : FunSpec(
          }
       }
 
+      test("insert with null named parameter") {
+         val mikrom =
+            Mikrom {
+               registerRowMapper { row ->
+                  Person(row.get("name"), row.get("age"))
+               }
+            }
+
+         val dataSource = prepareH2Database(
+            """
+               CREATE TABLE people_nullable (
+                  name VARCHAR(255),
+                  age INT
+               )
+            """.trimIndent(),
+         )
+
+         dataSource.transaction {
+            mikrom.execute(
+               Query("INSERT INTO people_nullable (name, age) VALUES (:name, :age)"),
+               mapOf("name" to "Alice", "age" to null),
+            )
+
+            mikrom.queryFor<Person>(
+               Query("SELECT * FROM people_nullable WHERE name = :name"),
+               mapOf("name" to "Alice"),
+            ) shouldBe listOf(Person("Alice", 0))
+         }
+      }
+
+      test("query with null named parameter in WHERE clause") {
+         val mikrom = Mikrom {}
+
+         val dataSource = prepareH2Database(
+            """
+               CREATE TABLE items_nullable (
+                  label VARCHAR(255),
+                  quantity INT
+               )
+            """.trimIndent(),
+         )
+
+         dataSource.transaction {
+            mikrom.execute(
+               Query("INSERT INTO items_nullable (label, quantity) VALUES (:label, :quantity)"),
+               mapOf("label" to "Apples", "quantity" to 5),
+               mapOf("label" to "Bananas", "quantity" to null),
+            )
+
+            mikrom.queryFor<Int>(
+               Query("SELECT COUNT(*) FROM items_nullable WHERE quantity IS NULL"),
+            ) shouldBe listOf(1)
+         }
+      }
+
+      test("batch execute with mix of null and non-null named parameters") {
+         val mikrom =
+            Mikrom {
+               registerRowMapper { row ->
+                  Person(row.get("name"), row.get("age"))
+               }
+            }
+
+         val dataSource = prepareH2Database(
+            """
+               CREATE TABLE people_mixed (
+                  name VARCHAR(255),
+                  age INT
+               )
+            """.trimIndent(),
+         )
+
+         dataSource.transaction {
+            mikrom.execute(
+               Query("INSERT INTO people_mixed (name, age) VALUES (:name, :age)"),
+               mapOf("name" to "Alice", "age" to 30),
+               mapOf("name" to "Bob", "age" to null),
+               mapOf("name" to null, "age" to 25),
+            )
+
+            mikrom.queryFor<Int>(
+               Query("SELECT COUNT(*) FROM people_mixed"),
+            ) shouldBe listOf(3)
+
+            mikrom.queryFor<Int>(
+               Query("SELECT COUNT(*) FROM people_mixed WHERE age IS NULL"),
+            ) shouldBe listOf(1)
+
+            mikrom.queryFor<Int>(
+               Query("SELECT COUNT(*) FROM people_mixed WHERE name IS NULL"),
+            ) shouldBe listOf(1)
+         }
+      }
+
       test("repeated named parameter in WHERE clause") {
          val mikrom =
             Mikrom {


### PR DESCRIPTION
## Summary
- Remove `filterNotNull()` from map-based `queryFor`/`execute` overloads that was stripping null parameter values, causing positional parameter count mismatches in `bindParameters`
- Widen `List<Any>` to `List<Any?>` in the positional overloads so overload resolution works correctly when `resolveParams` returns `List<Any?>`
- Apply the same fix to suspend variants (`suspendQueries.kt`, `queryFor.kt`)

## Test plan
- [x] Added test: insert with null named parameter
- [x] Added test: query with null named parameter in WHERE clause
- [x] Added test: batch execute with mix of null and non-null named parameters
- [x] All existing tests continue to pass
- [x] Full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)