### PR TITLE
Add TypedNull wrapper for R2DBC null binding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ Key architectural principles:
 - Generated test files are in `mikrom-compiler-plugin/test-gen/`
 - Test data is in `mikrom-compiler-plugin/testData/`
 
+When the compile plugin's IR output, the test's *.txt files will need to be regenerated.
+Delete them and then run the tests (which will fail once) then run them again to ensure they are working.
+
 ### Publishing
 - `./gradlew publishToMavenLocal` - Publish to local Maven repository
 - `./gradlew publish` - Publish to configured repositories

--- a/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/ir/MikromIrVisitor.kt
+++ b/mikrom-compiler-plugin/src/io/github/kantis/mikrom/plugin/ir/MikromIrVisitor.kt
@@ -14,8 +14,10 @@ import org.jetbrains.kotlin.ir.builders.irBlock
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irDelegatingConstructorCall
+import org.jetbrains.kotlin.ir.builders.irEqualsNull
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irGetObject
+import org.jetbrains.kotlin.ir.builders.irIfThenElse
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irString
 import org.jetbrains.kotlin.ir.builders.irTemporary
@@ -76,6 +78,9 @@ internal class MikromIrVisitor(
 
       private val ILLEGAL_STATE_EXCEPTION_CLASS_ID =
          ClassId.topLevel(ILLEGAL_STATE_EXCEPTION_FQ_NAME)
+
+      private val TYPED_NULL_CLASS_ID = ClassId(FqName("io.github.kantis.mikrom"), Name.identifier("TypedNull"))
+      private val KCLASS_CLASS_ID = ClassId.topLevel(FqName("kotlin.reflect.KClass"))
 
       private val PAIR_CLASS_ID = ClassId(FqName("kotlin"), Name.identifier("Pair"))
       private val TO_FQ_NAME = FqName("kotlin.to")
@@ -262,6 +267,11 @@ internal class MikromIrVisitor(
       val pairType = pairClass.typeWith(stringType, anyNType)
       val arrayOfPairType = pluginContext.irBuiltIns.arrayClass.typeWith(pairType)
 
+      // TypedNull constructor for wrapping nulls with type info
+      val typedNullClass = pluginContext.referenceClass(TYPED_NULL_CLASS_ID)!!
+      val typedNullConstructor = typedNullClass.owner.primaryConstructor!!
+      val kClassSymbol = pluginContext.referenceClass(KCLASS_CLASS_ID)!!
+
       return irBuilder.irBlockBody {
          // Build pairs: "propName" to value.propName for each constructor parameter
          val pairExpressions = primaryConstructor.parameters.map { ctorParam ->
@@ -269,16 +279,67 @@ internal class MikromIrVisitor(
                .single { it.name == ctorParam.name }
                .getter!!
 
-            var valueExpr: IrExpression = irCall(propertyGetter).apply {
-               dispatchReceiver = irGet(valueParam)
-            }
-
-            // Unwrap value classes to their underlying value
             val paramClass = ctorParam.type.classifierOrNull?.owner as? IrClass
-            if (paramClass?.isValue == true) {
-               val underlyingGetter = paramClass.properties.single().getter!!
-               valueExpr = irCall(underlyingGetter).apply {
-                  dispatchReceiver = valueExpr
+            val isValueClass = paramClass?.isValue == true
+
+            val valueExpr: IrExpression
+            if (ctorParam.type.isNullable()) {
+               // Determine the base type for TypedNull - use underlying type for value classes
+               val baseType = if (isValueClass) {
+                  paramClass.properties.single().getter!!.returnType.makeNotNull()
+               } else {
+                  ctorParam.type.makeNotNull()
+               }
+
+               val classRef = IrClassReferenceImpl(
+                  startOffset,
+                  endOffset,
+                  type = kClassSymbol.typeWith(baseType),
+                  symbol = baseType.classifierOrNull!!,
+                  classType = baseType,
+               )
+
+               val typedNullExpr = irCall(typedNullConstructor.symbol).apply {
+                  arguments[0] = classRef
+               }
+
+               // Store the property value in a temp to avoid duplicating the expression
+               val rawTemp = irTemporary(
+                  nameHint = "${ctorParam.name.asString()}\$raw",
+                  value = irCall(propertyGetter).apply {
+                     dispatchReceiver = irGet(valueParam)
+                  },
+               )
+
+               // For non-null branch: unwrap value class if needed
+               val nonNullExpr: IrExpression = if (isValueClass) {
+                  val underlyingGetter = paramClass!!.properties.single().getter!!
+                  irCall(underlyingGetter).apply {
+                     dispatchReceiver = irGet(rawTemp)
+                  }
+               } else {
+                  irGet(rawTemp)
+               }
+
+               // if (value == null) TypedNull(Type::class) else unwrappedValue
+               valueExpr = irIfThenElse(
+                  type = anyNType,
+                  condition = irEqualsNull(irGet(rawTemp)),
+                  thenPart = typedNullExpr,
+                  elsePart = nonNullExpr,
+               )
+            } else {
+               val rawValueExpr: IrExpression = irCall(propertyGetter).apply {
+                  dispatchReceiver = irGet(valueParam)
+               }
+               // Non-nullable: just unwrap value classes
+               valueExpr = if (isValueClass) {
+                  val underlyingGetter = paramClass.properties.single().getter!!
+                  irCall(underlyingGetter).apply {
+                     dispatchReceiver = rawValueExpr
+                  }
+               } else {
+                  rawValueExpr
                }
             }
 

--- a/mikrom-compiler-plugin/test-gen/io/github/kantis/mikrom/plugin/BoxTestGenerated.java
+++ b/mikrom-compiler-plugin/test-gen/io/github/kantis/mikrom/plugin/BoxTestGenerated.java
@@ -51,6 +51,18 @@ public class BoxTestGenerated extends AbstractBoxTest {
   }
 
   @Test
+  @TestMetadata("ParameterMappedNullable.kt")
+  public void testParameterMappedNullable() {
+    runTest("testData/box/ParameterMappedNullable.kt");
+  }
+
+  @Test
+  @TestMetadata("ParameterMappedNullableValueClass.kt")
+  public void testParameterMappedNullableValueClass() {
+    runTest("testData/box/ParameterMappedNullableValueClass.kt");
+  }
+
+  @Test
   @TestMetadata("ParameterMappedValueClass.kt")
   public void testParameterMappedValueClass() {
     runTest("testData/box/ParameterMappedValueClass.kt");

--- a/mikrom-compiler-plugin/testData/box/ParameterMappedNullable.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/ParameterMappedNullable.fir.ir.txt
@@ -1,0 +1,373 @@
+FILE fqName:<root> fileName:/ParameterMappedNullable.kt
+  CLASS CLASS name:NullableFields modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
+    annotations:
+      ParameterMapped
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.NullableFields
+    PROPERTY name:name visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'name: kotlin.String declared in <root>.NullableFields.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+        correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String declared in <root>.NullableFields'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.<get-name>' type=<root>.NullableFields origin=null
+    PROPERTY name:nickname visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:nickname type:kotlin.String? visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'nickname: kotlin.String? declared in <root>.NullableFields.<init>' type=kotlin.String? origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-nickname> visibility:public modality:FINAL returnType:kotlin.String?
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+        correspondingProperty: PROPERTY name:nickname visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-nickname> (): kotlin.String? declared in <root>.NullableFields'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nickname type:kotlin.String? visibility:private [final]' type=kotlin.String? origin=null
+              receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.<get-nickname>' type=<root>.NullableFields origin=null
+    PROPERTY name:age visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int? visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'age: kotlin.Int? declared in <root>.NullableFields.<init>' type=kotlin.Int? origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-age> visibility:public modality:FINAL returnType:kotlin.Int?
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+        correspondingProperty: PROPERTY name:age visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-age> (): kotlin.Int? declared in <root>.NullableFields'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int? visibility:private [final]' type=kotlin.Int? origin=null
+              receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.<get-age>' type=<root>.NullableFields origin=null
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.NullableFields.Companion
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] visibility:private returnType:<root>.NullableFields.Companion [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperAccessorKey] name:parameterMapper visibility:public modality:FINAL returnType:io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields.Companion
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun parameterMapper (): io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields> declared in <root>.NullableFields.Companion'
+            GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperClassKey] OBJECT name:$ParameterMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields>]' type=<root>.NullableFields.$ParameterMapper
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperClassKey] OBJECT name:$ParameterMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields>]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.NullableFields.$ParameterMapper
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperKey] visibility:private returnType:<root>.NullableFields.$ParameterMapper [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperClassKey] OBJECT name:$ParameterMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields>]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in io.github.kantis.mikrom.ParameterMapper
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in io.github.kantis.mikrom.ParameterMapper
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in io.github.kantis.mikrom.ParameterMapper
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperKey] name:mapParameters visibility:public modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlin.Any?>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields.$ParameterMapper
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperKey] kind:Regular name:value index:1 type:<root>.NullableFields
+        overridden:
+          public abstract fun mapParameters (value: T of io.github.kantis.mikrom.ParameterMapper): kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in io.github.kantis.mikrom.ParameterMapper
+        BLOCK_BODY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.String? [val]
+            CALL 'public final fun <get-nickname> (): kotlin.String? declared in <root>.NullableFields' type=kotlin.String? origin=null
+              ARG <this>: GET_VAR 'value: <root>.NullableFields declared in <root>.NullableFields.$ParameterMapper.mapParameters' type=<root>.NullableFields origin=null
+          VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Int? [val]
+            CALL 'public final fun <get-age> (): kotlin.Int? declared in <root>.NullableFields' type=kotlin.Int? origin=null
+              ARG <this>: GET_VAR 'value: <root>.NullableFields declared in <root>.NullableFields.$ParameterMapper.mapParameters' type=<root>.NullableFields origin=null
+          RETURN type=kotlin.Nothing from='public final fun mapParameters (value: <root>.NullableFields): kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.NullableFields.$ParameterMapper'
+            CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> origin=null
+              TYPE_ARG K: kotlin.String
+              TYPE_ARG V: kotlin.Any?
+              ARG pairs: VARARG type=kotlin.Array<kotlin.Pair<kotlin.String, kotlin.Any?>> varargElementType=kotlin.Pair<kotlin.String, kotlin.Any?>
+                CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<A of kotlin.to, B of kotlin.to> origin=null
+                  TYPE_ARG A: kotlin.String
+                  TYPE_ARG B: kotlin.Any?
+                  ARG <this>: CONST String type=kotlin.String value="name"
+                  ARG that: CALL 'public final fun <get-name> (): kotlin.String declared in <root>.NullableFields' type=kotlin.String origin=null
+                    ARG <this>: GET_VAR 'value: <root>.NullableFields declared in <root>.NullableFields.$ParameterMapper.mapParameters' type=<root>.NullableFields origin=null
+                CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<A of kotlin.to, B of kotlin.to> origin=null
+                  TYPE_ARG A: kotlin.String
+                  TYPE_ARG B: kotlin.Any?
+                  ARG <this>: CONST String type=kotlin.String value="nickname"
+                  ARG that: WHEN type=kotlin.Any? origin=null
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        ARG arg0: GET_VAR 'val tmp_0: kotlin.String? declared in <root>.NullableFields.$ParameterMapper.mapParameters' type=kotlin.String? origin=null
+                        ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                      then: CONSTRUCTOR_CALL 'public constructor <init> (type: kotlin.reflect.KClass<*>) declared in io.github.kantis.mikrom.TypedNull' type=io.github.kantis.mikrom.TypedNull origin=null
+                        ARG type: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+                    BRANCH
+                      if: CONST Boolean type=kotlin.Boolean value=true
+                      then: GET_VAR 'val tmp_0: kotlin.String? declared in <root>.NullableFields.$ParameterMapper.mapParameters' type=kotlin.String? origin=null
+                CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<A of kotlin.to, B of kotlin.to> origin=null
+                  TYPE_ARG A: kotlin.String
+                  TYPE_ARG B: kotlin.Any?
+                  ARG <this>: CONST String type=kotlin.String value="age"
+                  ARG that: WHEN type=kotlin.Any? origin=null
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        ARG arg0: GET_VAR 'val tmp_1: kotlin.Int? declared in <root>.NullableFields.$ParameterMapper.mapParameters' type=kotlin.Int? origin=null
+                        ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                      then: CONSTRUCTOR_CALL 'public constructor <init> (type: kotlin.reflect.KClass<*>) declared in io.github.kantis.mikrom.TypedNull' type=io.github.kantis.mikrom.TypedNull origin=null
+                        ARG type: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.Int>
+                    BRANCH
+                      if: CONST Boolean type=kotlin.Boolean value=true
+                      then: GET_VAR 'val tmp_1: kotlin.Int? declared in <root>.NullableFields.$ParameterMapper.mapParameters' type=kotlin.Int? origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.NullableFields [primary]
+      VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:nickname index:1 type:kotlin.String?
+      VALUE_PARAMETER kind:Regular name:age index:2 type:kotlin.Int?
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:NullableFields modality:FINAL visibility:public [data] superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.NullableFields'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.component1' type=<root>.NullableFields origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:component2 visibility:public modality:FINAL returnType:kotlin.String? [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component2 (): kotlin.String? declared in <root>.NullableFields'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nickname type:kotlin.String? visibility:private [final]' type=kotlin.String? origin=null
+            receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.component2' type=<root>.NullableFields origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:component3 visibility:public modality:FINAL returnType:kotlin.Int? [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component3 (): kotlin.Int? declared in <root>.NullableFields'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int? visibility:private [final]' type=kotlin.Int? origin=null
+            receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.component3' type=<root>.NullableFields origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL returnType:<root>.NullableFields
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.copy' type=<root>.NullableFields origin=null
+      VALUE_PARAMETER kind:Regular name:nickname index:2 type:kotlin.String?
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nickname type:kotlin.String? visibility:private [final]' type=kotlin.String? origin=null
+            receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.copy' type=<root>.NullableFields origin=null
+      VALUE_PARAMETER kind:Regular name:age index:3 type:kotlin.Int?
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int? visibility:private [final]' type=kotlin.Int? origin=null
+            receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.copy' type=<root>.NullableFields origin=null
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun copy (name: kotlin.String, nickname: kotlin.String?, age: kotlin.Int?): <root>.NullableFields declared in <root>.NullableFields'
+          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, nickname: kotlin.String?, age: kotlin.Int?) declared in <root>.NullableFields' type=<root>.NullableFields origin=null
+            ARG name: GET_VAR 'name: kotlin.String declared in <root>.NullableFields.copy' type=kotlin.String origin=null
+            ARG nickname: GET_VAR 'nickname: kotlin.String? declared in <root>.NullableFields.copy' type=kotlin.String? origin=null
+            ARG age: GET_VAR 'age: kotlin.Int? declared in <root>.NullableFields.copy' type=kotlin.Int? origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+              ARG arg0: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.equals' type=<root>.NullableFields origin=null
+              ARG arg1: GET_VAR 'other: kotlin.Any? declared in <root>.NullableFields.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.NullableFields'
+              CONST Boolean type=kotlin.Boolean value=true
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.NullableFields
+              GET_VAR 'other: kotlin.Any? declared in <root>.NullableFields.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.NullableFields'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:<root>.NullableFields [val]
+          TYPE_OP type=<root>.NullableFields origin=IMPLICIT_CAST typeOperand=<root>.NullableFields
+            GET_VAR 'other: kotlin.Any? declared in <root>.NullableFields.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.equals' type=<root>.NullableFields origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_2: <root>.NullableFields declared in <root>.NullableFields.equals' type=<root>.NullableFields origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.NullableFields'
+              CONST Boolean type=kotlin.Boolean value=false
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nickname type:kotlin.String? visibility:private [final]' type=kotlin.String? origin=null
+                  receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.equals' type=<root>.NullableFields origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nickname type:kotlin.String? visibility:private [final]' type=kotlin.String? origin=null
+                  receiver: GET_VAR 'val tmp_2: <root>.NullableFields declared in <root>.NullableFields.equals' type=<root>.NullableFields origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.NullableFields'
+              CONST Boolean type=kotlin.Boolean value=false
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int? visibility:private [final]' type=kotlin.Int? origin=null
+                  receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.equals' type=<root>.NullableFields origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int? visibility:private [final]' type=kotlin.Int? origin=null
+                  receiver: GET_VAR 'val tmp_2: <root>.NullableFields declared in <root>.NullableFields.equals' type=<root>.NullableFields origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.NullableFields'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.NullableFields'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      BLOCK_BODY
+        VAR name:result type:kotlin.Int [var]
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.hashCode' type=<root>.NullableFields origin=null
+        SET_VAR 'var result: kotlin.Int declared in <root>.NullableFields.hashCode' type=kotlin.Unit origin=EQ
+          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'var result: kotlin.Int declared in <root>.NullableFields.hashCode' type=kotlin.Int origin=null
+              ARG other: CONST Int type=kotlin.Int value=31
+            ARG other: WHEN type=kotlin.Int origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nickname type:kotlin.String? visibility:private [final]' type=kotlin.String? origin=null
+                    receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.hashCode' type=<root>.NullableFields origin=null
+                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                then: CONST Int type=kotlin.Int value=0
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+                  ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nickname type:kotlin.String? visibility:private [final]' type=kotlin.String? origin=null
+                    receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.hashCode' type=<root>.NullableFields origin=null
+        SET_VAR 'var result: kotlin.Int declared in <root>.NullableFields.hashCode' type=kotlin.Unit origin=EQ
+          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'var result: kotlin.Int declared in <root>.NullableFields.hashCode' type=kotlin.Int origin=null
+              ARG other: CONST Int type=kotlin.Int value=31
+            ARG other: WHEN type=kotlin.Int origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int? visibility:private [final]' type=kotlin.Int? origin=null
+                    receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.hashCode' type=<root>.NullableFields origin=null
+                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                then: CONST Int type=kotlin.Int value=0
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+                  ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int? visibility:private [final]' type=kotlin.Int? origin=null
+                    receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.hashCode' type=<root>.NullableFields origin=null
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.NullableFields'
+          GET_VAR 'var result: kotlin.Int declared in <root>.NullableFields.hashCode' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.NullableFields
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.NullableFields'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="NullableFields("
+            CONST String type=kotlin.String value="name="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.toString' type=<root>.NullableFields origin=null
+            CONST String type=kotlin.String value=", "
+            CONST String type=kotlin.String value="nickname="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:nickname type:kotlin.String? visibility:private [final]' type=kotlin.String? origin=null
+              receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.toString' type=<root>.NullableFields origin=null
+            CONST String type=kotlin.String value=", "
+            CONST String type=kotlin.String value="age="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:age type:kotlin.Int? visibility:private [final]' type=kotlin.Int? origin=null
+              receiver: GET_VAR '<this>: <root>.NullableFields declared in <root>.NullableFields.toString' type=<root>.NullableFields origin=null
+            CONST String type=kotlin.String value=")"
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:mapper type:io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields> [val]
+        CALL 'public final fun parameterMapper (): io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields> declared in <root>.NullableFields.Companion' type=io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields> origin=null
+          ARG <this>: GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=<root>.NullableFields.Companion
+      VAR name:params1 type:kotlin.collections.Map<kotlin.String, kotlin.Any?> [val]
+        CALL 'public abstract fun mapParameters (value: T of io.github.kantis.mikrom.ParameterMapper): kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in io.github.kantis.mikrom.ParameterMapper' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG <this>: GET_VAR 'val mapper: io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields> declared in <root>.box' type=io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields> origin=null
+          ARG value: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, nickname: kotlin.String?, age: kotlin.Int?) declared in <root>.NullableFields' type=<root>.NullableFields origin=null
+            ARG name: CONST String type=kotlin.String value="Alice"
+            ARG nickname: CONST String type=kotlin.String value="Ali"
+            ARG age: CONST Int type=kotlin.Int value=30
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Any?
+        ARG expected: CONST String type=kotlin.String value="Alice"
+        ARG actual: CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params1: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="name"
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Any?
+        ARG expected: CONST String type=kotlin.String value="Ali"
+        ARG actual: CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params1: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="nickname"
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Any?
+        ARG expected: CONST Int type=kotlin.Int value=30
+        ARG actual: CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params1: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="age"
+      VAR name:params2 type:kotlin.collections.Map<kotlin.String, kotlin.Any?> [val]
+        CALL 'public abstract fun mapParameters (value: T of io.github.kantis.mikrom.ParameterMapper): kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in io.github.kantis.mikrom.ParameterMapper' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG <this>: GET_VAR 'val mapper: io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields> declared in <root>.box' type=io.github.kantis.mikrom.ParameterMapper<<root>.NullableFields> origin=null
+          ARG value: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, nickname: kotlin.String?, age: kotlin.Int?) declared in <root>.NullableFields' type=<root>.NullableFields origin=null
+            ARG name: CONST String type=kotlin.String value="Bob"
+            ARG nickname: CONST Null type=kotlin.Nothing? value=null
+            ARG age: CONST Null type=kotlin.Nothing? value=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Any?
+        ARG expected: CONST String type=kotlin.String value="Bob"
+        ARG actual: CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params2: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="name"
+      VAR name:nicknameValue type:kotlin.Any? [val]
+        CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params2: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="nickname"
+      CALL 'public final fun assertTrue (actual: kotlin.Boolean, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG actual: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=io.github.kantis.mikrom.TypedNull
+          GET_VAR 'val nicknameValue: kotlin.Any? declared in <root>.box' type=kotlin.Any? origin=null
+        ARG message: STRING_CONCATENATION type=kotlin.String
+          CONST String type=kotlin.String value="Expected TypedNull for null nickname, got: "
+          GET_VAR 'val nicknameValue: kotlin.Any? declared in <root>.box' type=kotlin.Any? origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.reflect.KClass<out kotlin.Any>
+        ARG expected: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+        ARG actual: CALL 'public final fun <get-type> (): kotlin.reflect.KClass<*> declared in io.github.kantis.mikrom.TypedNull' type=kotlin.reflect.KClass<*> origin=GET_PROPERTY
+          ARG <this>: TYPE_OP type=io.github.kantis.mikrom.TypedNull origin=IMPLICIT_CAST typeOperand=io.github.kantis.mikrom.TypedNull
+            GET_VAR 'val nicknameValue: kotlin.Any? declared in <root>.box' type=kotlin.Any? origin=null
+      VAR name:ageValue type:kotlin.Any? [val]
+        CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params2: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="age"
+      CALL 'public final fun assertTrue (actual: kotlin.Boolean, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG actual: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=io.github.kantis.mikrom.TypedNull
+          GET_VAR 'val ageValue: kotlin.Any? declared in <root>.box' type=kotlin.Any? origin=null
+        ARG message: STRING_CONCATENATION type=kotlin.String
+          CONST String type=kotlin.String value="Expected TypedNull for null age, got: "
+          GET_VAR 'val ageValue: kotlin.Any? declared in <root>.box' type=kotlin.Any? origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.reflect.KClass<out kotlin.Any>
+        ARG expected: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:Int modality:FINAL visibility:public superTypes:[kotlin.Number; kotlin.Comparable<kotlin.Int>; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.Int>
+        ARG actual: CALL 'public final fun <get-type> (): kotlin.reflect.KClass<*> declared in io.github.kantis.mikrom.TypedNull' type=kotlin.reflect.KClass<*> origin=GET_PROPERTY
+          ARG <this>: TYPE_OP type=io.github.kantis.mikrom.TypedNull origin=IMPLICIT_CAST typeOperand=io.github.kantis.mikrom.TypedNull
+            GET_VAR 'val ageValue: kotlin.Any? declared in <root>.box' type=kotlin.Any? origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/mikrom-compiler-plugin/testData/box/ParameterMappedNullable.fir.txt
+++ b/mikrom-compiler-plugin/testData/box/ParameterMappedNullable.fir.txt
@@ -1,0 +1,54 @@
+FILE: ParameterMappedNullable.kt
+    @R|io/github/kantis/mikrom/generator/ParameterMapped|() public final data class NullableFields : R|kotlin/Any| {
+        public constructor(name: R|kotlin/String|, nickname: R|kotlin/String?|, age: R|kotlin/Int?|): R|NullableFields| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val name: R|kotlin/String| = R|<local>/name|
+            public get(): R|kotlin/String|
+
+        public final val nickname: R|kotlin/String?| = R|<local>/nickname|
+            public get(): R|kotlin/String?|
+
+        public final val age: R|kotlin/Int?| = R|<local>/age|
+            public get(): R|kotlin/Int?|
+
+        public final operator fun component1(): R|kotlin/String|
+
+        public final operator fun component2(): R|kotlin/String?|
+
+        public final operator fun component3(): R|kotlin/Int?|
+
+        public final fun copy(name: R|kotlin/String| = this@R|/NullableFields|.R|/NullableFields.name|, nickname: R|kotlin/String?| = this@R|/NullableFields|.R|/NullableFields.nickname|, age: R|kotlin/Int?| = this@R|/NullableFields|.R|/NullableFields.age|): R|NullableFields|
+
+        public final companion object Companion : R|kotlin/Any| {
+            public final fun parameterMapper(): R|io/github/kantis/mikrom/ParameterMapper<NullableFields>|
+
+            private constructor(): R|NullableFields.Companion|
+
+        }
+
+        public final object $ParameterMapper : R|io/github/kantis/mikrom/ParameterMapper<NullableFields>| {
+            public final fun mapParameters(value: R|NullableFields|): R|kotlin/collections/Map<kotlin/String, kotlin/Any?>|
+
+            private constructor(): R|NullableFields.$ParameterMapper|
+
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval mapper: R|io/github/kantis/mikrom/ParameterMapper<NullableFields>| = Q|NullableFields|.R|/NullableFields.Companion.parameterMapper|()
+        lval params1: R|kotlin/collections/Map<kotlin/String, kotlin/Any?>| = R|<local>/mapper|.R|SubstitutionOverride<io/github/kantis/mikrom/ParameterMapper.mapParameters: R|kotlin/collections/Map<kotlin/String, kotlin/Any?>|>|(R|/NullableFields.NullableFields|(String(Alice), String(Ali), Int(30)))
+        R|kotlin/test/assertEquals|<R|kotlin/Any?|>(String(Alice), R|<local>/params1|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(name)))
+        R|kotlin/test/assertEquals|<R|kotlin/Any?|>(String(Ali), R|<local>/params1|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(nickname)))
+        R|kotlin/test/assertEquals|<R|kotlin/Any?|>(Int(30), R|<local>/params1|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(age)))
+        lval params2: R|kotlin/collections/Map<kotlin/String, kotlin/Any?>| = R|<local>/mapper|.R|SubstitutionOverride<io/github/kantis/mikrom/ParameterMapper.mapParameters: R|kotlin/collections/Map<kotlin/String, kotlin/Any?>|>|(R|/NullableFields.NullableFields|(String(Bob), Null(null), Null(null)))
+        R|kotlin/test/assertEquals|<R|kotlin/Any?|>(String(Bob), R|<local>/params2|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(name)))
+        lval nicknameValue: R|kotlin/Any?| = R|<local>/params2|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(nickname))
+        R|kotlin/test/assertTrue|((R|<local>/nicknameValue| is R|io/github/kantis/mikrom/TypedNull|), <strcat>(String(Expected TypedNull for null nickname, got: ), R|<local>/nicknameValue|))
+        R|kotlin/test/assertEquals|<R|kotlin/reflect/KClass<out kotlin/Any>|>(<getClass>(Q|kotlin/String|), R|<local>/nicknameValue|.R|io/github/kantis/mikrom/TypedNull.type|)
+        lval ageValue: R|kotlin/Any?| = R|<local>/params2|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(age))
+        R|kotlin/test/assertTrue|((R|<local>/ageValue| is R|io/github/kantis/mikrom/TypedNull|), <strcat>(String(Expected TypedNull for null age, got: ), R|<local>/ageValue|))
+        R|kotlin/test/assertEquals|<R|kotlin/reflect/KClass<out kotlin/Any>|>(<getClass>(Q|kotlin/Int|), R|<local>/ageValue|.R|io/github/kantis/mikrom/TypedNull.type|)
+        ^box String(OK)
+    }

--- a/mikrom-compiler-plugin/testData/box/ParameterMappedNullable.kt
+++ b/mikrom-compiler-plugin/testData/box/ParameterMappedNullable.kt
@@ -1,0 +1,37 @@
+// FIR_DUMP
+// DUMP_IR
+
+import io.github.kantis.mikrom.TypedNull
+import io.github.kantis.mikrom.generator.ParameterMapped
+import kotlin.test.*
+
+@ParameterMapped
+data class NullableFields(
+   val name: String,
+   val nickname: String?,
+   val age: Int?,
+)
+
+fun box(): String {
+   val mapper = NullableFields.parameterMapper()
+
+   // Non-null values should pass through normally
+   val params1 = mapper.mapParameters(NullableFields("Alice", "Ali", 30))
+   assertEquals("Alice", params1["name"])
+   assertEquals("Ali", params1["nickname"])
+   assertEquals(30, params1["age"])
+
+   // Null values should be wrapped in TypedNull
+   val params2 = mapper.mapParameters(NullableFields("Bob", null, null))
+   assertEquals("Bob", params2["name"])
+
+   val nicknameValue = params2["nickname"]
+   assertTrue(nicknameValue is TypedNull, "Expected TypedNull for null nickname, got: $nicknameValue")
+   assertEquals(String::class, nicknameValue.type)
+
+   val ageValue = params2["age"]
+   assertTrue(ageValue is TypedNull, "Expected TypedNull for null age, got: $ageValue")
+   assertEquals(Int::class, ageValue.type)
+
+   return "OK"
+}

--- a/mikrom-compiler-plugin/testData/box/ParameterMappedNullableValueClass.fir.ir.txt
+++ b/mikrom-compiler-plugin/testData/box/ParameterMappedNullableValueClass.fir.ir.txt
@@ -1,0 +1,348 @@
+FILE fqName:<root> fileName:/ParameterMappedNullableValueClass.kt
+  CLASS CLASS name:Email modality:FINAL visibility:public [value] superTypes:[kotlin.Any]
+    annotations:
+      JvmInline
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Email
+    PROPERTY name:value visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'value: kotlin.String declared in <root>.Email.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-value> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Email
+        correspondingProperty: PROPERTY name:value visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-value> (): kotlin.String declared in <root>.Email'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Email declared in <root>.Email.<get-value>' type=<root>.Email origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.Email [primary]
+      VALUE_PARAMETER kind:Regular name:value index:0 type:kotlin.String
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Email modality:FINAL visibility:public [value] superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN GENERATED_SINGLE_FIELD_VALUE_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Email
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.Email
+              GET_VAR 'other: kotlin.Any? declared in <root>.Email.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Email'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:<root>.Email [val]
+          TYPE_OP type=<root>.Email origin=IMPLICIT_CAST typeOperand=<root>.Email
+            GET_VAR 'other: kotlin.Any? declared in <root>.Email.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.Email declared in <root>.Email.equals' type=<root>.Email origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_0: <root>.Email declared in <root>.Email.equals' type=<root>.Email origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Email'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.Email'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_SINGLE_FIELD_VALUE_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Email
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.Email'
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Email declared in <root>.Email.hashCode' type=<root>.Email origin=null
+    FUN GENERATED_SINGLE_FIELD_VALUE_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Email
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.Email'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="Email("
+            CONST String type=kotlin.String value="value="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Email declared in <root>.Email.toString' type=<root>.Email origin=null
+            CONST String type=kotlin.String value=")"
+  CLASS CLASS name:UserWithEmail modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
+    annotations:
+      ParameterMapped
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.UserWithEmail
+    PROPERTY name:name visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'name: kotlin.String declared in <root>.UserWithEmail.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-name> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail
+        correspondingProperty: PROPERTY name:name visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-name> (): kotlin.String declared in <root>.UserWithEmail'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.<get-name>' type=<root>.UserWithEmail origin=null
+    PROPERTY name:email visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:email type:<root>.Email? visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'email: <root>.Email? declared in <root>.UserWithEmail.<init>' type=<root>.Email? origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-email> visibility:public modality:FINAL returnType:<root>.Email?
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail
+        correspondingProperty: PROPERTY name:email visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-email> (): <root>.Email? declared in <root>.UserWithEmail'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:<root>.Email? visibility:private [final]' type=<root>.Email? origin=null
+              receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.<get-email>' type=<root>.UserWithEmail origin=null
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.UserWithEmail.Companion
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] visibility:private returnType:<root>.UserWithEmail.Companion [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlin.Any
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperAccessorKey] name:parameterMapper visibility:public modality:FINAL returnType:io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail.Companion
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun parameterMapper (): io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail> declared in <root>.UserWithEmail.Companion'
+            GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperClassKey] OBJECT name:$ParameterMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail>]' type=<root>.UserWithEmail.$ParameterMapper
+    CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperClassKey] OBJECT name:$ParameterMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail>]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.UserWithEmail.$ParameterMapper
+      CONSTRUCTOR GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperKey] visibility:private returnType:<root>.UserWithEmail.$ParameterMapper [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperClassKey] OBJECT name:$ParameterMapper modality:FINAL visibility:public superTypes:[io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail>]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in io.github.kantis.mikrom.ParameterMapper
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in io.github.kantis.mikrom.ParameterMapper
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in io.github.kantis.mikrom.ParameterMapper
+      FUN GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperKey] name:mapParameters visibility:public modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlin.Any?>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail.$ParameterMapper
+        VALUE_PARAMETER GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateParameterMapperKey] kind:Regular name:value index:1 type:<root>.UserWithEmail
+        overridden:
+          public abstract fun mapParameters (value: T of io.github.kantis.mikrom.ParameterMapper): kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in io.github.kantis.mikrom.ParameterMapper
+        BLOCK_BODY
+          VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:<root>.Email? [val]
+            CALL 'public final fun <get-email> (): <root>.Email? declared in <root>.UserWithEmail' type=<root>.Email? origin=null
+              ARG <this>: GET_VAR 'value: <root>.UserWithEmail declared in <root>.UserWithEmail.$ParameterMapper.mapParameters' type=<root>.UserWithEmail origin=null
+          RETURN type=kotlin.Nothing from='public final fun mapParameters (value: <root>.UserWithEmail): kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.UserWithEmail.$ParameterMapper'
+            CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> origin=null
+              TYPE_ARG K: kotlin.String
+              TYPE_ARG V: kotlin.Any?
+              ARG pairs: VARARG type=kotlin.Array<kotlin.Pair<kotlin.String, kotlin.Any?>> varargElementType=kotlin.Pair<kotlin.String, kotlin.Any?>
+                CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<A of kotlin.to, B of kotlin.to> origin=null
+                  TYPE_ARG A: kotlin.String
+                  TYPE_ARG B: kotlin.Any?
+                  ARG <this>: CONST String type=kotlin.String value="name"
+                  ARG that: CALL 'public final fun <get-name> (): kotlin.String declared in <root>.UserWithEmail' type=kotlin.String origin=null
+                    ARG <this>: GET_VAR 'value: <root>.UserWithEmail declared in <root>.UserWithEmail.$ParameterMapper.mapParameters' type=<root>.UserWithEmail origin=null
+                CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<A of kotlin.to, B of kotlin.to> origin=null
+                  TYPE_ARG A: kotlin.String
+                  TYPE_ARG B: kotlin.Any?
+                  ARG <this>: CONST String type=kotlin.String value="email"
+                  ARG that: WHEN type=kotlin.Any? origin=null
+                    BRANCH
+                      if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                        ARG arg0: GET_VAR 'val tmp_1: <root>.Email? declared in <root>.UserWithEmail.$ParameterMapper.mapParameters' type=<root>.Email? origin=null
+                        ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                      then: CONSTRUCTOR_CALL 'public constructor <init> (type: kotlin.reflect.KClass<*>) declared in io.github.kantis.mikrom.TypedNull' type=io.github.kantis.mikrom.TypedNull origin=null
+                        ARG type: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+                    BRANCH
+                      if: CONST Boolean type=kotlin.Boolean value=true
+                      then: CALL 'public final fun <get-value> (): kotlin.String declared in <root>.Email' type=kotlin.String origin=null
+                        ARG <this>: GET_VAR 'val tmp_1: <root>.Email? declared in <root>.UserWithEmail.$ParameterMapper.mapParameters' type=<root>.Email? origin=null
+    CONSTRUCTOR visibility:public returnType:<root>.UserWithEmail [primary]
+      VALUE_PARAMETER kind:Regular name:name index:0 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:email index:1 type:<root>.Email?
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:UserWithEmail modality:FINAL visibility:public [data] superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.UserWithEmail'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.component1' type=<root>.UserWithEmail origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:component2 visibility:public modality:FINAL returnType:<root>.Email? [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun component2 (): <root>.Email? declared in <root>.UserWithEmail'
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:<root>.Email? visibility:private [final]' type=<root>.Email? origin=null
+            receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.component2' type=<root>.UserWithEmail origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL returnType:<root>.UserWithEmail
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail
+      VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.copy' type=<root>.UserWithEmail origin=null
+      VALUE_PARAMETER kind:Regular name:email index:2 type:<root>.Email?
+        EXPRESSION_BODY
+          GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:<root>.Email? visibility:private [final]' type=<root>.Email? origin=null
+            receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.copy' type=<root>.UserWithEmail origin=null
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public final fun copy (name: kotlin.String, email: <root>.Email?): <root>.UserWithEmail declared in <root>.UserWithEmail'
+          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, email: <root>.Email?) declared in <root>.UserWithEmail' type=<root>.UserWithEmail origin=null
+            ARG name: GET_VAR 'name: kotlin.String declared in <root>.UserWithEmail.copy' type=kotlin.String origin=null
+            ARG email: GET_VAR 'email: <root>.Email? declared in <root>.UserWithEmail.copy' type=<root>.Email? origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+      BLOCK_BODY
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+              ARG arg0: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.equals' type=<root>.UserWithEmail origin=null
+              ARG arg1: GET_VAR 'other: kotlin.Any? declared in <root>.UserWithEmail.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.UserWithEmail'
+              CONST Boolean type=kotlin.Boolean value=true
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: TYPE_OP type=kotlin.Boolean origin=NOT_INSTANCEOF typeOperand=<root>.UserWithEmail
+              GET_VAR 'other: kotlin.Any? declared in <root>.UserWithEmail.equals' type=kotlin.Any? origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.UserWithEmail'
+              CONST Boolean type=kotlin.Boolean value=false
+        VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:<root>.UserWithEmail [val]
+          TYPE_OP type=<root>.UserWithEmail origin=IMPLICIT_CAST typeOperand=<root>.UserWithEmail
+            GET_VAR 'other: kotlin.Any? declared in <root>.UserWithEmail.equals' type=kotlin.Any? origin=null
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.equals' type=<root>.UserWithEmail origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR 'val tmp_2: <root>.UserWithEmail declared in <root>.UserWithEmail.equals' type=<root>.UserWithEmail origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.UserWithEmail'
+              CONST Boolean type=kotlin.Boolean value=false
+        WHEN type=kotlin.Unit origin=null
+          BRANCH
+            if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:<root>.Email? visibility:private [final]' type=<root>.Email? origin=null
+                  receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.equals' type=<root>.UserWithEmail origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:<root>.Email? visibility:private [final]' type=<root>.Email? origin=null
+                  receiver: GET_VAR 'val tmp_2: <root>.UserWithEmail declared in <root>.UserWithEmail.equals' type=<root>.UserWithEmail origin=null
+            then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.UserWithEmail'
+              CONST Boolean type=kotlin.Boolean value=false
+        RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.UserWithEmail'
+          CONST Boolean type=kotlin.Boolean value=true
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      BLOCK_BODY
+        VAR name:result type:kotlin.Int [var]
+          CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.hashCode' type=<root>.UserWithEmail origin=null
+        SET_VAR 'var result: kotlin.Int declared in <root>.UserWithEmail.hashCode' type=kotlin.Unit origin=EQ
+          CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+            ARG <this>: CALL 'public final fun times (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=null
+              ARG <this>: GET_VAR 'var result: kotlin.Int declared in <root>.UserWithEmail.hashCode' type=kotlin.Int origin=null
+              ARG other: CONST Int type=kotlin.Int value=31
+            ARG other: WHEN type=kotlin.Int origin=null
+              BRANCH
+                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                  ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:<root>.Email? visibility:private [final]' type=<root>.Email? origin=null
+                    receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.hashCode' type=<root>.UserWithEmail origin=null
+                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                then: CONST Int type=kotlin.Int value=0
+              BRANCH
+                if: CONST Boolean type=kotlin.Boolean value=true
+                then: CALL 'public open fun hashCode (): kotlin.Int declared in <root>.Email' type=kotlin.Int origin=null
+                  ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:<root>.Email? visibility:private [final]' type=<root>.Email? origin=null
+                    receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.hashCode' type=<root>.UserWithEmail origin=null
+        RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.UserWithEmail'
+          GET_VAR 'var result: kotlin.Int declared in <root>.UserWithEmail.hashCode' type=kotlin.Int origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.UserWithEmail
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.UserWithEmail'
+          STRING_CONCATENATION type=kotlin.String
+            CONST String type=kotlin.String value="UserWithEmail("
+            CONST String type=kotlin.String value="name="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:name type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.toString' type=<root>.UserWithEmail origin=null
+            CONST String type=kotlin.String value=", "
+            CONST String type=kotlin.String value="email="
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:email type:<root>.Email? visibility:private [final]' type=<root>.Email? origin=null
+              receiver: GET_VAR '<this>: <root>.UserWithEmail declared in <root>.UserWithEmail.toString' type=<root>.UserWithEmail origin=null
+            CONST String type=kotlin.String value=")"
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:mapper type:io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail> [val]
+        CALL 'public final fun parameterMapper (): io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail> declared in <root>.UserWithEmail.Companion' type=io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail> origin=null
+          ARG <this>: GET_OBJECT 'CLASS GENERATED[io.github.kantis.mikrom.plugin.MikromGenerateCompanionKey] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlin.Any]' type=<root>.UserWithEmail.Companion
+      VAR name:params1 type:kotlin.collections.Map<kotlin.String, kotlin.Any?> [val]
+        CALL 'public abstract fun mapParameters (value: T of io.github.kantis.mikrom.ParameterMapper): kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in io.github.kantis.mikrom.ParameterMapper' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG <this>: GET_VAR 'val mapper: io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail> declared in <root>.box' type=io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail> origin=null
+          ARG value: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, email: <root>.Email?) declared in <root>.UserWithEmail' type=<root>.UserWithEmail origin=null
+            ARG name: CONST String type=kotlin.String value="Alice"
+            ARG email: CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.String) declared in <root>.Email' type=<root>.Email origin=null
+              ARG value: CONST String type=kotlin.String value="alice@example.com"
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Any?
+        ARG expected: CONST String type=kotlin.String value="Alice"
+        ARG actual: CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params1: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="name"
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Any?
+        ARG expected: CONST String type=kotlin.String value="alice@example.com"
+        ARG actual: CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params1: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="email"
+      VAR name:params2 type:kotlin.collections.Map<kotlin.String, kotlin.Any?> [val]
+        CALL 'public abstract fun mapParameters (value: T of io.github.kantis.mikrom.ParameterMapper): kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in io.github.kantis.mikrom.ParameterMapper' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG <this>: GET_VAR 'val mapper: io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail> declared in <root>.box' type=io.github.kantis.mikrom.ParameterMapper<<root>.UserWithEmail> origin=null
+          ARG value: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, email: <root>.Email?) declared in <root>.UserWithEmail' type=<root>.UserWithEmail origin=null
+            ARG name: CONST String type=kotlin.String value="Bob"
+            ARG email: CONST Null type=kotlin.Nothing? value=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.Any?
+        ARG expected: CONST String type=kotlin.String value="Bob"
+        ARG actual: CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params2: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="name"
+      VAR name:emailValue type:kotlin.Any? [val]
+        CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+          ARG <this>: GET_VAR 'val params2: kotlin.collections.Map<kotlin.String, kotlin.Any?> declared in <root>.box' type=kotlin.collections.Map<kotlin.String, kotlin.Any?> origin=null
+          ARG key: CONST String type=kotlin.String value="email"
+      CALL 'public final fun assertTrue (actual: kotlin.Boolean, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        ARG actual: TYPE_OP type=kotlin.Boolean origin=INSTANCEOF typeOperand=io.github.kantis.mikrom.TypedNull
+          GET_VAR 'val emailValue: kotlin.Any? declared in <root>.box' type=kotlin.Any? origin=null
+        ARG message: STRING_CONCATENATION type=kotlin.String
+          CONST String type=kotlin.String value="Expected TypedNull for null email, got: "
+          GET_VAR 'val emailValue: kotlin.Any? declared in <root>.box' type=kotlin.Any? origin=null
+      CALL 'public final fun assertEquals <T> (expected: T of kotlin.test.assertEquals, actual: T of kotlin.test.assertEquals, message: kotlin.String?): kotlin.Unit declared in kotlin.test' type=kotlin.Unit origin=null
+        TYPE_ARG T: kotlin.reflect.KClass<out kotlin.Any>
+        ARG expected: CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB CLASS name:String modality:FINAL visibility:public superTypes:[kotlin.Comparable<kotlin.String>; kotlin.CharSequence; java.io.Serializable]' type=kotlin.reflect.KClass<kotlin.String>
+        ARG actual: CALL 'public final fun <get-type> (): kotlin.reflect.KClass<*> declared in io.github.kantis.mikrom.TypedNull' type=kotlin.reflect.KClass<*> origin=GET_PROPERTY
+          ARG <this>: TYPE_OP type=io.github.kantis.mikrom.TypedNull origin=IMPLICIT_CAST typeOperand=io.github.kantis.mikrom.TypedNull
+            GET_VAR 'val emailValue: kotlin.Any? declared in <root>.box' type=kotlin.Any? origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/mikrom-compiler-plugin/testData/box/ParameterMappedNullableValueClass.fir.txt
+++ b/mikrom-compiler-plugin/testData/box/ParameterMappedNullableValueClass.fir.txt
@@ -1,0 +1,54 @@
+FILE: ParameterMappedNullableValueClass.kt
+    @R|kotlin/jvm/JvmInline|() public final value class Email : R|kotlin/Any| {
+        public constructor(value: R|kotlin/String|): R|Email| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val value: R|kotlin/String| = R|<local>/value|
+            public get(): R|kotlin/String|
+
+    }
+    @R|io/github/kantis/mikrom/generator/ParameterMapped|() public final data class UserWithEmail : R|kotlin/Any| {
+        public constructor(name: R|kotlin/String|, email: R|Email?|): R|UserWithEmail| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val name: R|kotlin/String| = R|<local>/name|
+            public get(): R|kotlin/String|
+
+        public final val email: R|Email?| = R|<local>/email|
+            public get(): R|Email?|
+
+        public final operator fun component1(): R|kotlin/String|
+
+        public final operator fun component2(): R|Email?|
+
+        public final fun copy(name: R|kotlin/String| = this@R|/UserWithEmail|.R|/UserWithEmail.name|, email: R|Email?| = this@R|/UserWithEmail|.R|/UserWithEmail.email|): R|UserWithEmail|
+
+        public final companion object Companion : R|kotlin/Any| {
+            public final fun parameterMapper(): R|io/github/kantis/mikrom/ParameterMapper<UserWithEmail>|
+
+            private constructor(): R|UserWithEmail.Companion|
+
+        }
+
+        public final object $ParameterMapper : R|io/github/kantis/mikrom/ParameterMapper<UserWithEmail>| {
+            public final fun mapParameters(value: R|UserWithEmail|): R|kotlin/collections/Map<kotlin/String, kotlin/Any?>|
+
+            private constructor(): R|UserWithEmail.$ParameterMapper|
+
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval mapper: R|io/github/kantis/mikrom/ParameterMapper<UserWithEmail>| = Q|UserWithEmail|.R|/UserWithEmail.Companion.parameterMapper|()
+        lval params1: R|kotlin/collections/Map<kotlin/String, kotlin/Any?>| = R|<local>/mapper|.R|SubstitutionOverride<io/github/kantis/mikrom/ParameterMapper.mapParameters: R|kotlin/collections/Map<kotlin/String, kotlin/Any?>|>|(R|/UserWithEmail.UserWithEmail|(String(Alice), R|/Email.Email|(String(alice@example.com))))
+        R|kotlin/test/assertEquals|<R|kotlin/Any?|>(String(Alice), R|<local>/params1|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(name)))
+        R|kotlin/test/assertEquals|<R|kotlin/Any?|>(String(alice@example.com), R|<local>/params1|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(email)))
+        lval params2: R|kotlin/collections/Map<kotlin/String, kotlin/Any?>| = R|<local>/mapper|.R|SubstitutionOverride<io/github/kantis/mikrom/ParameterMapper.mapParameters: R|kotlin/collections/Map<kotlin/String, kotlin/Any?>|>|(R|/UserWithEmail.UserWithEmail|(String(Bob), Null(null)))
+        R|kotlin/test/assertEquals|<R|kotlin/Any?|>(String(Bob), R|<local>/params2|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(name)))
+        lval emailValue: R|kotlin/Any?| = R|<local>/params2|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlin/Any?|>|(String(email))
+        R|kotlin/test/assertTrue|((R|<local>/emailValue| is R|io/github/kantis/mikrom/TypedNull|), <strcat>(String(Expected TypedNull for null email, got: ), R|<local>/emailValue|))
+        R|kotlin/test/assertEquals|<R|kotlin/reflect/KClass<out kotlin/Any>|>(<getClass>(Q|kotlin/String|), R|<local>/emailValue|.R|io/github/kantis/mikrom/TypedNull.type|)
+        ^box String(OK)
+    }

--- a/mikrom-compiler-plugin/testData/box/ParameterMappedNullableValueClass.kt
+++ b/mikrom-compiler-plugin/testData/box/ParameterMappedNullableValueClass.kt
@@ -1,0 +1,34 @@
+// FIR_DUMP
+// DUMP_IR
+
+import io.github.kantis.mikrom.TypedNull
+import io.github.kantis.mikrom.generator.ParameterMapped
+import kotlin.test.*
+
+@JvmInline
+value class Email(val value: String)
+
+@ParameterMapped
+data class UserWithEmail(
+   val name: String,
+   val email: Email?,
+)
+
+fun box(): String {
+   val mapper = UserWithEmail.parameterMapper()
+
+   // Non-null value class should be unwrapped
+   val params1 = mapper.mapParameters(UserWithEmail("Alice", Email("alice@example.com")))
+   assertEquals("Alice", params1["name"])
+   assertEquals("alice@example.com", params1["email"])
+
+   // Null value class should be TypedNull with the underlying type
+   val params2 = mapper.mapParameters(UserWithEmail("Bob", null))
+   assertEquals("Bob", params2["name"])
+
+   val emailValue = params2["email"]
+   assertTrue(emailValue is TypedNull, "Expected TypedNull for null email, got: $emailValue")
+   assertEquals(String::class, emailValue.type)
+
+   return "OK"
+}

--- a/mikrom/mikrom-core/api/mikrom-core.api
+++ b/mikrom/mikrom-core/api/mikrom-core.api
@@ -123,6 +123,11 @@ public final class io/github/kantis/mikrom/TypeMismatchException : java/lang/Run
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class io/github/kantis/mikrom/TypedNull {
+	public fun <init> (Lkotlin/reflect/KClass;)V
+	public final fun getType ()Lkotlin/reflect/KClass;
+}
+
 public final class io/github/kantis/mikrom/convert/DefaultConversionsKt {
 	public static final fun commonDefaultConversions ()Lio/github/kantis/mikrom/convert/TypeConversions;
 	public static final fun defaultConversions ()Lio/github/kantis/mikrom/convert/TypeConversions;

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/TypedNull.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/TypedNull.kt
@@ -1,0 +1,5 @@
+package io.github.kantis.mikrom
+
+import kotlin.reflect.KClass
+
+public class TypedNull(public val type: KClass<*>)

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/queryFor.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/queryFor.kt
@@ -29,7 +29,7 @@ public suspend inline fun <reified T> Mikrom.queryFor(
 context(transaction: SuspendingTransaction)
 public suspend inline fun <reified T : Any> Mikrom.queryFor(
    @Language("SQL") query: Query,
-   params: List<Any?>,
+   params: List<Any>,
 ): Flow<T> {
    if (T::class in nonMappedPrimitives) {
       return transaction.query(query, params).map { it.singleValue() as T }
@@ -41,7 +41,7 @@ public suspend inline fun <reified T : Any> Mikrom.queryFor(
 context(transaction: SuspendingTransaction)
 public suspend inline fun <reified T : Any> Mikrom.queryFor(
    @Language("SQL") query: Query,
-   params: Map<String, Any?>,
+   params: Map<String, Any>,
 ): Flow<T> {
    val parsed = parseNamedParameters(query)
    return queryFor(parsed.sql, parsed.resolveParams(params))

--- a/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/suspendQueries.kt
+++ b/mikrom/mikrom-core/src/commonMain/kotlin/io/github/kantis/mikrom/suspend/suspendQueries.kt
@@ -50,7 +50,7 @@ public suspend fun Mikrom.executeStreaming(
 context(transaction: SuspendingTransaction)
 public suspend fun Mikrom.execute(
    @Language("SQL") query: Query,
-   params: Map<String, Any?>,
+   params: Map<String, Any>,
 ) {
    val parsed = parseNamedParameters(query)
    execute(parsed.sql, parsed.resolveParams(params))

--- a/mikrom/mikrom-jdbc/src/jvmMain/kotlin/JdbcTransaction.kt
+++ b/mikrom/mikrom-jdbc/src/jvmMain/kotlin/JdbcTransaction.kt
@@ -2,6 +2,7 @@ package io.github.kantis.mikrom.jdbc
 
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.Row
+import io.github.kantis.mikrom.TypedNull
 import io.github.kantis.mikrom.datasource.Transaction
 import java.math.BigDecimal
 import java.sql.Connection
@@ -54,6 +55,7 @@ public class JdbcTransaction(private val connection: Connection) : Transaction {
             is LocalDateTime -> statement.setTimestamp(index + 1, Timestamp.valueOf(param))
             is BigDecimal -> statement.setBigDecimal(index + 1, param)
             is Instant -> statement.setTimestamp(index + 1, Timestamp.from(param))
+            is TypedNull -> statement.setNull(index + 1, Types.NULL)
             null -> statement.setNull(index + 1, Types.NULL)
             else -> error("Unsupported parameter type: ${param::class.simpleName} at index ${index + 1} with value $param")
          }

--- a/mikrom/mikrom-r2dbc/src/jvmMain/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransaction.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmMain/kotlin/io/github/kantis/mikrom/r2dbc/R2dbcTransaction.kt
@@ -2,6 +2,7 @@ package io.github.kantis.mikrom.r2dbc
 
 import io.github.kantis.mikrom.Query
 import io.github.kantis.mikrom.Row
+import io.github.kantis.mikrom.TypedNull
 import io.github.kantis.mikrom.buildRow
 import io.github.kantis.mikrom.suspend.SuspendingTransaction
 import io.r2dbc.spi.Connection
@@ -82,11 +83,10 @@ public class R2dbcTransaction(private val connection: Connection, override val c
       params: List<*>,
    ) {
       params.forEachIndexed { index, param ->
-         if (param == null) {
-            // TODO: How can we know the type of the column?
-            statement.bindNull(index, Object::class.java)
-         } else {
-            statement.bind(index, param)
+         when (param) {
+            is TypedNull -> statement.bindNull(index, param.type.java)
+            null -> statement.bindNull(index, Any::class.java)
+            else -> statement.bind(index, param)
          }
       }
    }

--- a/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/postgres/R2dbcDataTypesTest.kt
+++ b/mikrom/mikrom-r2dbc/src/jvmTest/kotlin/io/github/kantis/mikrom/r2dbc/postgres/R2dbcDataTypesTest.kt
@@ -1,6 +1,7 @@
 package io.github.kantis.mikrom.r2dbc.postgres
 
 import io.github.kantis.mikrom.Mikrom
+import io.github.kantis.mikrom.TypedNull
 import io.github.kantis.mikrom.get
 import io.github.kantis.mikrom.getOrNull
 import io.github.kantis.mikrom.r2dbc.PooledR2dbcDataSource
@@ -127,6 +128,44 @@ class R2dbcDataTypesTest : FunSpec(
                     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                """.trimIndent(),
                listOf(null, null, null, null, null, null, null, null, null),
+            )
+
+            val records = mikrom.queryFor<DataTypeRecord>("SELECT * FROM data_types").toList()
+            records.size shouldBe 1
+
+            val record = records[0]
+            record.stringField shouldBe null
+            record.intField shouldBe null
+            record.longField shouldBe null
+            record.booleanField shouldBe null
+            record.doubleField shouldBe null
+            record.decimalField shouldBe null
+            record.dateField shouldBe null
+            record.timestampField shouldBe null
+            record.uuidField shouldBe null
+         }
+      }
+
+      test("handle TypedNull values with correct type binding") {
+         dataSource.suspendingTransaction {
+            mikrom.execute(
+               """
+                    INSERT INTO data_types (
+                        string_field, int_field, long_field, boolean_field,
+                        double_field, decimal_field, date_field, timestamp_field, uuid_field
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+               """.trimIndent(),
+               listOf(
+                  TypedNull(String::class),
+                  TypedNull(Int::class),
+                  TypedNull(Long::class),
+                  TypedNull(Boolean::class),
+                  TypedNull(Double::class),
+                  TypedNull(BigDecimal::class),
+                  TypedNull(LocalDate::class),
+                  TypedNull(LocalDateTime::class),
+                  TypedNull(UUID::class),
+               ),
             )
 
             val records = mikrom.queryFor<DataTypeRecord>("SELECT * FROM data_types").toList()


### PR DESCRIPTION
## Summary
- Add `TypedNull(KClass)` class in mikrom-core to carry type information for null values
- Update compiler plugin to emit `TypedNull(Type::class)` instead of bare `null` for nullable `@ParameterMapped` properties (including nullable value classes)
- Update R2DBC binding to use `TypedNull.type.java` for `bindNull()`, providing proper type info
- Update JDBC binding to handle `TypedNull` by stripping the wrapper (JDBC uses `Types.NULL` regardless)
- Change `Map<String, Any?>` params to `Map<String, Any>` since nulls are now wrapped in `TypedNull`

## Test plan
- [x] Compiler plugin tests: nullable fields produce `TypedNull` with correct type
- [x] Compiler plugin tests: nullable value classes produce `TypedNull` with underlying type
- [x] JDBC tests pass with `TypedNull` unwrapping
- [x] R2DBC integration test verifies `TypedNull` binding against PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)