### PR TITLE
Add SQLite JDBC tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ testcontainers-mariadb = { module = "org.testcontainers:testcontainers-mariadb",
 testcontainers-mssql = { module = "org.testcontainers:testcontainers-mssqlserver", version.ref = "testcontainers" }
 testcontainers-oracle = { module = "org.testcontainers:testcontainers-oracle-xe", version.ref = "testcontainers" }
 hikari = { module = "com.zaxxer:HikariCP", version = "6.3.0" }
+sqlite = { module = "org.xerial:sqlite-jdbc", version = "3.49.1.0" }
 
 kotestPlugin-embeddedCompiler = { module = "io.kotest:kotest-framework-multiplatform-plugin-embeddable-compiler" }
 kotestPlugin-multiplatform = { module = "io.kotest:kotest-framework-multiplatform-plugin-gradle" }

--- a/mikrom/mikrom-jdbc/build.gradle.kts
+++ b/mikrom/mikrom-jdbc/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
                implementation(libs.testcontainers.mariadb)
                implementation(libs.testcontainers.mssql)
                implementation(libs.testcontainers.oracle)
+               implementation(libs.sqlite)
             }
          }
       }

--- a/mikrom/mikrom-jdbc/src/jvmMain/kotlin/JdbcConverters.kt
+++ b/mikrom/mikrom-jdbc/src/jvmMain/kotlin/JdbcConverters.kt
@@ -3,8 +3,10 @@ package io.github.kantis.mikrom.jdbc
 import io.github.kantis.mikrom.convert.TypeConverters
 import java.math.BigDecimal
 import java.sql.Timestamp
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import javax.sql.DataSource
 
 public fun jdbcConverters(dataSource: DataSource): TypeConverters {
@@ -15,6 +17,8 @@ public fun jdbcConverters(dataSource: DataSource): TypeConverters {
       driverName.contains("MSSQL", ignoreCase = true) ||
          driverName.contains("Microsoft", ignoreCase = true) ||
          driverName.contains("SQL Server", ignoreCase = true) -> mssqlJdbcConverters()
+
+      driverName.contains("SQLite", ignoreCase = true) -> sqliteJdbcConverters()
 
       else -> TypeConverters.EMPTY
    }
@@ -33,4 +37,26 @@ private fun oracleJdbcConverters(): TypeConverters =
 private fun mssqlJdbcConverters(): TypeConverters =
    TypeConverters.Builder().apply {
       register<Int, Boolean> { it != 0 }
+   }.build()
+
+private fun sqliteJdbcConverters(): TypeConverters =
+   TypeConverters.Builder().apply {
+      register<Int, Boolean> { it != 0 }
+      register<Int, BigDecimal> { BigDecimal(it) }
+      register<Long, LocalDate> {
+         Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate()
+      }
+      register<Long, LocalDateTime> {
+         Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDateTime()
+      }
+      register<String, LocalDate> { s ->
+         s.toLongOrNull()?.let {
+            Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate()
+         } ?: LocalDate.parse(s)
+      }
+      register<String, LocalDateTime> { s ->
+         s.toLongOrNull()?.let {
+            Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDateTime()
+         } ?: LocalDateTime.parse(s)
+      }
    }.build()

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/io/github/kantis/mikrom/jdbc/JdbcTestDialect.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/io/github/kantis/mikrom/jdbc/JdbcTestDialect.kt
@@ -256,6 +256,53 @@ object MssqlJdbcDialect : JdbcTestDialect {
       """.trimIndent()
 }
 
+object SqliteJdbcDialect : JdbcTestDialect {
+   override val name = "SQLite"
+   override val supportsUuid = false
+
+   override fun truncateTable(table: String): String = "DELETE FROM $table"
+
+   override fun createBooksTable() =
+      """
+      CREATE TABLE books (
+          author TEXT,
+          title TEXT,
+          number_of_pages INTEGER
+      )
+      """.trimIndent()
+
+   override fun createTestRecordsTable() =
+      """
+      CREATE TABLE test_records (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT
+      )
+      """.trimIndent()
+
+   override fun createDataTypesTable() =
+      """
+      CREATE TABLE data_types (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          string_field TEXT,
+          int_field INTEGER,
+          long_field INTEGER,
+          boolean_field INTEGER,
+          double_field REAL,
+          decimal_field NUMERIC(10,2),
+          date_field TEXT,
+          timestamp_field TEXT
+      )
+      """.trimIndent()
+
+   override fun createPeopleTable() =
+      """
+      CREATE TABLE people (
+          name TEXT,
+          age INTEGER
+      )
+      """.trimIndent()
+}
+
 object OracleJdbcDialect : JdbcTestDialect {
    override val name = "Oracle"
    override val supportsUuid = false

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/io/github/kantis/mikrom/jdbc/sqlite/SqliteHelpers.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/io/github/kantis/mikrom/jdbc/sqlite/SqliteHelpers.kt
@@ -1,0 +1,32 @@
+package io.github.kantis.mikrom.jdbc.sqlite
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.github.kantis.mikrom.jdbc.JdbcDataSource
+import io.kotest.core.spec.Spec
+import org.intellij.lang.annotations.Language
+import java.sql.DriverManager
+
+fun Spec.prepareSqliteDatabase(
+   @Language("SQL") vararg statements: String,
+): JdbcDataSource {
+   val dbName = this::class.simpleName?.lowercase() ?: error("Unknown spec")
+   val connectionString = "jdbc:sqlite:file:$dbName?mode=memory&cache=shared"
+   DriverManager.registerDriver(org.sqlite.JDBC())
+   val hikariDataSource = HikariDataSource(
+      HikariConfig().apply {
+         jdbcUrl = connectionString
+         driverClassName = "org.sqlite.JDBC"
+         isAutoCommit = false
+      },
+   )
+   hikariDataSource.connection.use { conn ->
+      conn.autoCommit = true
+      statements.forEach {
+         conn.createStatement().use { statement ->
+            statement.execute(it)
+         }
+      }
+   }
+   return JdbcDataSource(hikariDataSource)
+}

--- a/mikrom/mikrom-jdbc/src/jvmTest/kotlin/io/github/kantis/mikrom/jdbc/sqlite/SqliteJdbcTests.kt
+++ b/mikrom/mikrom-jdbc/src/jvmTest/kotlin/io/github/kantis/mikrom/jdbc/sqlite/SqliteJdbcTests.kt
@@ -1,0 +1,36 @@
+package io.github.kantis.mikrom.jdbc.sqlite
+
+import io.github.kantis.mikrom.jdbc.JdbcDataSource
+import io.github.kantis.mikrom.jdbc.SqliteJdbcDialect
+import io.github.kantis.mikrom.jdbc.factories.basicInsertQueryTests
+import io.github.kantis.mikrom.jdbc.factories.dataTypeTests
+import io.github.kantis.mikrom.jdbc.factories.namedParamTests
+import io.github.kantis.mikrom.jdbc.factories.parameterMapperTests
+import io.github.kantis.mikrom.jdbc.factories.queryingForPrimitivesTests
+import io.github.kantis.mikrom.jdbc.factories.transactionTests
+import io.kotest.core.spec.style.FunSpec
+
+class SqliteJdbcTests : FunSpec(
+   {
+      val dialect = SqliteJdbcDialect
+      lateinit var dataSource: JdbcDataSource
+
+      beforeSpec {
+         dataSource = prepareSqliteDatabase(
+            dialect.createBooksTable(),
+            dialect.createTestRecordsTable(),
+            dialect.createDataTypesTable(),
+            dialect.createPeopleTable(),
+         )
+      }
+
+      val dataSourceProvider = { dataSource }
+
+      include(basicInsertQueryTests(dialect, dataSourceProvider))
+      include(transactionTests(dialect, dataSourceProvider))
+      include(dataTypeTests(dialect, dataSourceProvider))
+      include(namedParamTests(dialect, dataSourceProvider))
+      include(parameterMapperTests(dialect, dataSourceProvider))
+      include(queryingForPrimitivesTests(dialect, dataSourceProvider))
+   },
+)


### PR DESCRIPTION
## Summary
- Add SQLite as a tested database alongside the existing 6 databases (H2, PostgreSQL, MySQL, MariaDB, MSSQL, Oracle)
- SQLite is lightweight and in-memory like H2, requiring no Testcontainers
- Add SQLite-specific type converters in `JdbcConverters.kt` for `Int→Boolean`, `Int→BigDecimal`, and epoch millis `String/Long→LocalDate/LocalDateTime`

## Test plan
- [x] All 22 SQLite tests pass (`./gradlew :mikrom:mikrom-jdbc:jvmTest --tests "io.github.kantis.mikrom.jdbc.sqlite.*"`)
- [x] All 23 H2 tests still pass
- [x] `ktlintFormat` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)