### PR TITLE
Fixing groupId

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
    idea
 }
 
-group = "io.github.kantis"
+group = "io.github.kantis.mikrom"
 version = findProperty("version") ?: "0.1.0-SNAPSHOT"
 
 nmcpAggregation {
@@ -17,7 +17,7 @@ nmcpAggregation {
    }
 }
 
-dependencies  {
+dependencies {
    nmcpAggregation(projects.mikrom.mikromCore)
    nmcpAggregation(projects.mikrom.mikromJdbc)
    nmcpAggregation(projects.mikrom.mikromR2dbc)
@@ -48,8 +48,7 @@ idea {
    }
 }
 
-
-//tasks {
+// tasks {
 //   val apiCheck by registering {
 //      dependsOn(gradle.includedBuild("mikrom").task(":mikrom-core:apiCheck"))
 //      dependsOn(gradle.includedBuild("mikrom").task(":mikrom-jdbc:apiCheck"))
@@ -91,4 +90,4 @@ idea {
 //      dependsOn(gradle.includedBuild("mikrom-gradle-plugin").task(":ktlintFormat"))
 //   }
 //
-//}
+// }

--- a/mikrom-compiler-plugin/build.gradle.kts
+++ b/mikrom-compiler-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
    `java-test-fixtures`
 }
 
-group = "io.github.kantis"
+group = "io.github.kantis.mikrom"
 version = findProperty("version") ?: "0.1.0-SNAPSHOT"
 
 java {

--- a/mikrom-gradle-plugin/build.gradle.kts
+++ b/mikrom-gradle-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
    id("mikrom.conventions.lang.kotlin-jvm")
 }
 
-group = "io.github.kantis"
+group = "io.github.kantis.mikrom"
 version = project.property("version") ?: "0.2.0-SNAPSHOT"
 
 dependencies {

--- a/mikrom-gradle-plugin/src/main/kotlin/io/github/kantis/mikrom/gradle/MikromGradlePlugin.kt
+++ b/mikrom-gradle-plugin/src/main/kotlin/io/github/kantis/mikrom/gradle/MikromGradlePlugin.kt
@@ -21,7 +21,7 @@ public class MikromGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
    override fun getPluginArtifact(): SubpluginArtifact =
       SubpluginArtifact(
-         groupId = "io.github.kantis",
+         groupId = "io.github.kantis.mikrom",
          artifactId = "mikrom-compiler-plugin",
          version = extension.compilerPluginVersion.get(),
       )

--- a/mikrom/build.gradle.kts
+++ b/mikrom/build.gradle.kts
@@ -2,5 +2,5 @@ plugins {
    id("mikrom.conventions.base")
 }
 
-group = "io.github.kantis"
+group = "io.github.kantis.mikrom"
 version = "0.1.0-SNAPSHOT"


### PR DESCRIPTION
was intended to be `io.github.kantis.mikrom` but missed the `.mikrom` suffix